### PR TITLE
Fixes Preview Providers

### DIFF
--- a/Mochi Diffusion/Views/AppView.swift
+++ b/Mochi Diffusion/Views/AppView.swift
@@ -31,7 +31,7 @@ struct AppView: View {
 
 struct AppView_Previews: PreviewProvider {
     static let genStore = GeneratorStore()
-    
+
     static var previews: some View {
         AppView().previewLayout(.sizeThatFits)
             .environmentObject(genStore)

--- a/Mochi Diffusion/Views/AppView.swift
+++ b/Mochi Diffusion/Views/AppView.swift
@@ -30,7 +30,10 @@ struct AppView: View {
 }
 
 struct AppView_Previews: PreviewProvider {
+    static let genStore = GeneratorStore()
+    
     static var previews: some View {
         AppView().previewLayout(.sizeThatFits)
+            .environmentObject(genStore)
     }
 }

--- a/Mochi Diffusion/Views/GalleryToolbarView.swift
+++ b/Mochi Diffusion/Views/GalleryToolbarView.swift
@@ -164,7 +164,7 @@ struct GalleryToolbarView: View {
 
 struct GalleryToolbarView_Previews: PreviewProvider {
     static let genStore = GeneratorStore()
-    
+
     static var previews: some View {
         GalleryToolbarView()
             .environmentObject(genStore)

--- a/Mochi Diffusion/Views/GalleryToolbarView.swift
+++ b/Mochi Diffusion/Views/GalleryToolbarView.swift
@@ -163,7 +163,10 @@ struct GalleryToolbarView: View {
 }
 
 struct GalleryToolbarView_Previews: PreviewProvider {
+    static let genStore = GeneratorStore()
+    
     static var previews: some View {
         GalleryToolbarView()
+            .environmentObject(genStore)
     }
 }

--- a/Mochi Diffusion/Views/InspectorView.swift
+++ b/Mochi Diffusion/Views/InspectorView.swift
@@ -145,7 +145,10 @@ struct InspectorView: View {
 }
 
 struct InspectorView_Previews: PreviewProvider {
+    static let genStore = GeneratorStore()
+    
     static var previews: some View {
         InspectorView()
+            .environmentObject(genStore)
     }
 }

--- a/Mochi Diffusion/Views/InspectorView.swift
+++ b/Mochi Diffusion/Views/InspectorView.swift
@@ -146,7 +146,7 @@ struct InspectorView: View {
 
 struct InspectorView_Previews: PreviewProvider {
     static let genStore = GeneratorStore()
-    
+
     static var previews: some View {
         InspectorView()
             .environmentObject(genStore)

--- a/Mochi Diffusion/Views/SidebarControls/ModelView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ModelView.swift
@@ -83,7 +83,7 @@ struct ModelView: View {
 
 struct ModelView_Previews: PreviewProvider {
     static let genStore = GeneratorStore()
-    
+
     static var previews: some View {
         ModelView()
             .environmentObject(genStore)

--- a/Mochi Diffusion/Views/SidebarControls/ModelView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ModelView.swift
@@ -82,7 +82,10 @@ struct ModelView: View {
 }
 
 struct ModelView_Previews: PreviewProvider {
+    static let genStore = GeneratorStore()
+    
     static var previews: some View {
         ModelView()
+            .environmentObject(genStore)
     }
 }


### PR DESCRIPTION
Added missing GeneratorStore instance to SwiftUI previews
Note: Some views are still missing previews, but this appears intentional, so I fixed 4 existing previews