### PR TITLE
Quicklook Fixes (Issue #138)

### DIFF
--- a/Mochi Diffusion/Model/Store.swift
+++ b/Mochi Diffusion/Model/Store.swift
@@ -264,7 +264,7 @@ final class GeneratorStore: ObservableObject {
     }
 
     func quicklookCurrentImage() {
-        guard let sdi = getSelectedImage, let img = sdi.image else { return }
+        guard let sdi = getSelectedImage, let img = sdi.image else { quicklookURL = nil; return }
         quicklookURL = try? img.asNSImage().temporaryFileURL()
     }
 
@@ -291,6 +291,11 @@ final class GeneratorStore: ObservableObject {
         if index <= selectedImageIndex {
             if selectedImageIndex != 0 || images.isEmpty {
                 selectImage(index: selectedImageIndex - 1)
+            }
+            // Actively selects image instead of passively
+            // This calls any associated functionality in selectImage
+            else if selectedImageIndex == 0 && !images.isEmpty {
+                selectImage(index: 0)
             }
         }
     }


### PR DESCRIPTION
Fixes issue #138.

Dismisses quicklook whenever image becomes unavailable. 
When deleting images on index 0, calls selectImage.

New behavior: If quicklook is open and the final image is deleted, quicklook is closed. If quicklook is open and the first image out of multiple is deleted, quicklook switches to the newly selected first image.