### PR TITLE
Fix Quick Look anomalies when the window is manually closed

### DIFF
--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -31,7 +31,15 @@ final class ImageController: ObservableObject {
     var seed: UInt32 = 0
 
     @Published
-    var quicklookURL: URL?
+    var quicklookURL: URL? {
+        didSet {
+            // When QuickLook is manually dismissed with its close button, the system will set this to nil.
+            // Propagate the change to quicklookId, but prevent infinite didSet loops.
+            if quicklookURL == nil, oldValue != nil {
+                quicklookId = nil
+            }
+        }
+    }
 
     private var quicklookId: UUID? {
         didSet {


### PR DESCRIPTION
This fixes the two issues reported under #164.
Apparently I didn't test what happens if I just close the QL window, but the bugs make sense now.

And are squashed.