### PR TITLE
Fix crash when selecting an invalid model

### DIFF
--- a/Mochi Diffusion/Views/SidebarControls/ModelView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ModelView.swift
@@ -10,21 +10,18 @@ import SwiftUI
 
 struct ModelView: View {
     @EnvironmentObject private var controller: ImageController
-    #if arch(arm64)
-    @State private var isShowingComputeUnitPopover = false
-    #endif
 
     var body: some View {
         Text("Model:")
         HStack {
-            Picker("", selection: $controller.currentModel.onChange(modelChanged)) {
+            Picker("", selection: $controller.currentModel) {
                 ForEach(controller.models) { model in
                     Text(verbatim: model.name).tag(Optional(model))
                 }
             }
             .labelsHidden()
             #if arch(arm64)
-            .popover(isPresented: $isShowingComputeUnitPopover, arrowEdge: .top) {
+            .popover(isPresented: $controller.presentingComputeUnitSelection, arrowEdge: .top) {
                 VStack(alignment: .leading, spacing: 0) {
                     Text("Select Compute Unit option")
                         .fontWeight(.bold)
@@ -47,21 +44,13 @@ struct ModelView: View {
 
                     HStack {
                         Button {
-                            Task {
-                                ImageController.shared.mlComputeUnit = .cpuAndNeuralEngine
-                                await ImageController.shared.loadModels()
-                                isShowingComputeUnitPopover = false
-                            }
+                            controller.computeUnitSelected(.cpuAndNeuralEngine)
                         } label: {
                             Text("Use Neural Engine")
                         }
 
                         Button {
-                            Task {
-                                ImageController.shared.mlComputeUnit = .cpuAndGPU
-                                await ImageController.shared.loadModels()
-                                isShowingComputeUnitPopover = false
-                            }
+                            controller.computeUnitSelected(.cpuAndGPU)
                         } label: {
                             Text("Use GPU")
                         }
@@ -72,18 +61,12 @@ struct ModelView: View {
             #endif
 
             Button {
-                Task { await ImageController.shared.loadModels() }
+                Task { await controller.loadModels() }
             } label: {
                 Image(systemName: "arrow.clockwise")
                     .frame(minWidth: 18)
             }
         }
-    }
-
-    func modelChanged(to value: SDModel?) {
-        #if arch(arm64)
-        isShowingComputeUnitPopover.toggle()
-        #endif
     }
 }
 

--- a/Mochi Diffusion/Views/SidebarControls/ModelView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ModelView.swift
@@ -32,7 +32,7 @@ struct ModelView: View {
                     Spacer()
 
                     Text(
-                        "\(controller.currentModel!.name) model",
+                        "\(controller.modelName) model",
                         comment: "Label displaying the currently selected model name"
                     )
 


### PR DESCRIPTION
Fixes #165.

And improves the data race that happened between the compute unit popover and the model loading by asking first, then doing the load.

It's working locally (both ARM and Rosetta), but there is still one issue I haven't figured out: when I dismiss the popover from the controller with `presentingComputeUnitSelection = false`, the apps spits out 8 lines of SwiftUI warnings:

```
[SwiftUI] Publishing changes from within view updates is not allowed, this will cause undefined behavior.
```

I know by experiments that it's not timing-related, since a DispatchQueue.main.asyncAfter does not fix it.

---

If you have an idea how to evade it, or if we could just ignore it, please let me know.