### PR TITLE
Add option to set starting image

### DIFF
--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		036BFC29294B9F7600D8AD04 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 036BFC28294B9F7600D8AD04 /* Preview Assets.xcassets */; };
 		036BFC4E294B9FDB00D8AD04 /* Path in Frameworks */ = {isa = PBXBuildFile; productRef = 036BFC4D294B9FDB00D8AD04 /* Path */; };
 		0373FF5429A9165600C0180F /* AppCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0373FF5329A9165600C0180F /* AppCommands.swift */; };
+		0380934329AD504600EDBC8E /* StartingImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0380934229AD504600EDBC8E /* StartingImageView.swift */; };
 		0386DF8B2950D29400CA4CEB /* InspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0386DF8A2950D29400CA4CEB /* InspectorView.swift */; };
 		0386DF8D2950F25500CA4CEB /* GalleryToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0386DF8C2950F25500CA4CEB /* GalleryToolbarView.swift */; };
 		0388DEB0297B00FC008B1C1C /* CompactSlider in Frameworks */ = {isa = PBXBuildFile; productRef = 0388DEAF297B00FC008B1C1C /* CompactSlider */; };
@@ -106,6 +107,7 @@
 		03732B72296948360042C8B1 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		0373FF5329A9165600C0180F /* AppCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCommands.swift; sourceTree = "<group>"; };
 		0377877D297892B6002E3926 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		0380934229AD504600EDBC8E /* StartingImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartingImageView.swift; sourceTree = "<group>"; };
 		0386DF8A2950D29400CA4CEB /* InspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorView.swift; sourceTree = "<group>"; };
 		0386DF8C2950F25500CA4CEB /* GalleryToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryToolbarView.swift; sourceTree = "<group>"; };
 		038994DB2985D111007F5A61 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				03D280F1294FD60E00C7D184 /* PromptView.swift */,
+				0380934229AD504600EDBC8E /* StartingImageView.swift */,
 				035EDFF2295A1FBF00080D18 /* NumberOfImagesView.swift */,
 				035EDFF7295A216500080D18 /* StepsView.swift */,
 				035EDFF9295A219200080D18 /* GuidanceScaleView.swift */,
@@ -509,9 +512,9 @@
 				03D43B7829660A1300604911 /* GalleryView.swift in Sources */,
 				03D43B7A29660A2600604911 /* GalleryItemView.swift in Sources */,
 				035EDFF8295A216500080D18 /* StepsView.swift in Sources */,
-				03FD2317295F480F006EEEE2 /* ViewModifiers.swift in Sources */,
 				03061E6229AB9C06009AA2A2 /* FocusController.swift in Sources */,
 				03FD231B295F7A81006EEEE2 /* Upscaler.swift in Sources */,
+				0380934329AD504600EDBC8E /* StartingImageView.swift in Sources */,
 				03173C152999F5C700B03456 /* ImageController.swift in Sources */,
 				036BFC22294B9F7500D8AD04 /* App.swift in Sources */,
 				03EA52CE297B66C800CDF661 /* SidebarView.swift in Sources */,

--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		0352E2A5294E2591003FBF25 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 0352E2A4294E2591003FBF25 /* Sparkle */; };
 		0352E2A7294E3148003FBF25 /* HelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0352E2A6294E3148003FBF25 /* HelpCommands.swift */; };
 		0352E2AA294EA0E1003FBF25 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0352E2A9294EA0E1003FBF25 /* AppView.swift */; };
-		0352E2AE294EA2B4003FBF25 /* ErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0352E2AD294EA2B4003FBF25 /* ErrorBanner.swift */; };
+		0352E2AE294EA2B4003FBF25 /* MessageBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0352E2AD294EA2B4003FBF25 /* MessageBanner.swift */; };
 		0352E2B1294EA30D003FBF25 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0352E2B0294EA30D003FBF25 /* Extensions.swift */; };
 		0352E2B5294EA887003FBF25 /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0352E2B4294EA887003FBF25 /* Functions.swift */; };
 		035E76F42970E79A008DDFDE /* CVPixelBuffer+Resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035E76F32970E79A008DDFDE /* CVPixelBuffer+Resize.swift */; };
@@ -86,7 +86,7 @@
 		0352E2A6294E3148003FBF25 /* HelpCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpCommands.swift; sourceTree = "<group>"; };
 		0352E2A8294E414D003FBF25 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
 		0352E2A9294EA0E1003FBF25 /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
-		0352E2AD294EA2B4003FBF25 /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
+		0352E2AD294EA2B4003FBF25 /* MessageBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBanner.swift; sourceTree = "<group>"; };
 		0352E2B0294EA30D003FBF25 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		0352E2B4294EA887003FBF25 /* Functions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Functions.swift; sourceTree = "<group>"; };
 		035E76F32970E79A008DDFDE /* CVPixelBuffer+Resize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CVPixelBuffer+Resize.swift"; sourceTree = "<group>"; };
@@ -252,11 +252,11 @@
 				035EDFF1295A1F8F00080D18 /* SidebarControls */,
 				0352E2A9294EA0E1003FBF25 /* AppView.swift */,
 				03E075782968A153003488F9 /* CircularProgressView.swift */,
-				0352E2AD294EA2B4003FBF25 /* ErrorBanner.swift */,
 				03D43B7929660A2600604911 /* GalleryItemView.swift */,
 				0386DF8C2950F25500CA4CEB /* GalleryToolbarView.swift */,
 				03D43B7729660A1300604911 /* GalleryView.swift */,
 				0386DF8A2950D29400CA4CEB /* InspectorView.swift */,
+				0352E2AD294EA2B4003FBF25 /* MessageBanner.swift */,
 				03B1ACA7295167B900302F54 /* SettingsView.swift */,
 				03EA52CD297B66C800CDF661 /* SidebarView.swift */,
 			);
@@ -494,7 +494,7 @@
 				03173C18299B3C1300B03456 /* ImageStore.swift in Sources */,
 				035EDFFC295A21D600080D18 /* SizeView.swift in Sources */,
 				0395B3112995C70400465B73 /* Scheduler.swift in Sources */,
-				0352E2AE294EA2B4003FBF25 /* ErrorBanner.swift in Sources */,
+				0352E2AE294EA2B4003FBF25 /* MessageBanner.swift in Sources */,
 				0386DF8B2950D29400CA4CEB /* InspectorView.swift in Sources */,
 				0373FF5429A9165600C0180F /* AppCommands.swift in Sources */,
 				03D280F2294FD60E00C7D184 /* PromptView.swift in Sources */,

--- a/Mochi Diffusion/App.swift
+++ b/Mochi Diffusion/App.swift
@@ -59,7 +59,7 @@ struct MochiDiffusionApp: App {
             AppCommands(updater: updaterController.updater)
             FileCommands(store: store)
             SidebarCommands()
-            ImageCommands(controller: controller, generator: generator, store: store)
+            ImageCommands(controller: controller, store: store)
             HelpCommands()
         }
         .defaultSize(width: 1_120, height: 670)

--- a/Mochi Diffusion/Main Menu/ImageCommands.swift
+++ b/Mochi Diffusion/Main Menu/ImageCommands.swift
@@ -9,13 +9,12 @@ import SwiftUI
 
 struct ImageCommands: Commands {
     @ObservedObject var controller: ImageController
-    @ObservedObject var generator: ImageGenerator
     @ObservedObject var store: ImageStore
 
     var body: some Commands {
         CommandMenu("Image") {
             Section {
-                if case .running = generator.state {
+                if case .running = controller.state {
                     Button {
                         Task { await ImageGenerator.shared.stopGenerate() }
                     } label: {

--- a/Mochi Diffusion/Views/GalleryToolbarView.swift
+++ b/Mochi Diffusion/Views/GalleryToolbarView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 struct GalleryToolbarView: View {
     @Binding var isShowingInspector: Bool
-    @EnvironmentObject private var generator: ImageGenerator
+    @EnvironmentObject private var controller: ImageController
     @EnvironmentObject private var store: ImageStore
     @State private var isStatusPopoverShown = false
 
     var body: some View {
-        if case .loading = generator.state {
+        if case .loading = controller.state {
             Button {
                 self.isStatusPopoverShown.toggle()
             } label: {
@@ -36,10 +36,10 @@ struct GalleryToolbarView: View {
             }
         }
 
-        if case let .running(progress) = generator.state, let progress = progress, progress.stepCount > 0 {
+        if case let .running(progress) = controller.state, let progress = progress, progress.stepCount > 0 {
             let step = Int(progress.step) + 1
             let stepValue = Double(step) / Double(progress.stepCount)
-            let progressValue = Double(generator.queueProgress.index + 1) / Double(generator.queueProgress.total)
+            let progressValue = Double(controller.queueProgress.index + 1) / Double(controller.queueProgress.total)
 
             Button {
                 self.isStatusPopoverShown.toggle()
@@ -53,7 +53,7 @@ struct GalleryToolbarView: View {
                     comment: "Text displaying the current step progress and count"
                 )
                 let imageCountLabel = String(
-                    localized: "Image \(generator.queueProgress.index + 1) of \(generator.queueProgress.total)",
+                    localized: "Image \(controller.queueProgress.index + 1) of \(controller.queueProgress.total)",
                     comment: "Text displaying the image generation progress and count"
                 )
                 VStack(spacing: 12) {
@@ -191,7 +191,7 @@ struct GalleryToolbarView: View {
 struct GalleryToolbarView_Previews: PreviewProvider {
     static var previews: some View {
         GalleryToolbarView(isShowingInspector: .constant(true))
-            .environmentObject(ImageGenerator.shared)
+            .environmentObject(ImageController.shared)
             .environmentObject(ImageStore.shared)
     }
 }

--- a/Mochi Diffusion/Views/GalleryView.swift
+++ b/Mochi Diffusion/Views/GalleryView.swift
@@ -114,10 +114,12 @@ struct GalleryView: View {
                     )
                 }
 
-                Button {
-                    Task { await ImageController.shared.selectStartingImage(sdi: sdi) }
-                } label: {
-                    Text("Set as Starting Image")
+                if let image = sdi.image, image.width == 512 && image.height == 512 {
+                    Button {
+                        Task { await ImageController.shared.selectStartingImage(sdi: sdi) }
+                    } label: {
+                        Text("Set as Starting Image")
+                    }
                 }
             }
             if sdi.upscaler.isEmpty {

--- a/Mochi Diffusion/Views/GalleryView.swift
+++ b/Mochi Diffusion/Views/GalleryView.swift
@@ -75,69 +75,7 @@ struct GalleryView: View {
                                 Task { await ImageController.shared.select(sdi.id) }
                             })
                             .contextMenu {
-                                Section {
-                                    Button {
-                                        Task { await ImageController.shared.copyImage(sdi) }
-                                    } label: {
-                                        Text(
-                                            "Copy",
-                                            comment: "Copy image to the clipboard"
-                                        )
-                                    }
-
-                                    Button {
-                                        ImageController.shared.copyToPrompt(sdi)
-                                    } label: {
-                                        Text(
-                                            "Copy Options to Sidebar",
-                                            comment: "Copy image's generation options to the prompt input sidebar"
-                                        )
-                                    }
-
-                                    Button {
-                                        Task { await sdi.saveAs() }
-                                    } label: {
-                                        Text(
-                                            "Save As...",
-                                            comment: "Show the save image dialog"
-                                        )
-                                    }
-                                }
-                                if sdi.upscaler.isEmpty || !sdi.path.isEmpty {
-                                    Section {
-                                        if sdi.upscaler.isEmpty {
-                                            Button {
-                                                Task { await ImageController.shared.upscale(sdi) }
-                                            } label: {
-                                                Text(
-                                                    "Convert to High Resolution",
-                                                    comment: "Convert image to high resolution"
-                                                )
-                                            }
-                                        }
-
-                                        if !sdi.path.isEmpty {
-                                            Button {
-                                                NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: sdi.path).absoluteURL])
-                                            } label: {
-                                                Text(
-                                                    "Show in Finder",
-                                                    comment: "Show image with Finder"
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                                Section {
-                                    Button {
-                                        Task { await ImageController.shared.removeImage(sdi) }
-                                    } label: {
-                                        Text(
-                                            "Remove",
-                                            comment: "Remove image from the gallery"
-                                        )
-                                    }
-                                }
+                                GalleryItemContextMenuView(sdi: sdi)
                             }
                     }
                 }
@@ -149,6 +87,80 @@ struct GalleryView: View {
     @ViewBuilder
     private var emptyGalleryView: some View {
         Color.clear
+    }
+
+    struct GalleryItemContextMenuView: View {
+        let sdi: SDImage
+
+        var body: some View {
+            Section {
+                Button {
+                    Task { await ImageController.shared.copyImage(sdi) }
+                } label: {
+                    Text(
+                        "Copy",
+                        comment: "Copy image to the clipboard"
+                    )
+                }
+
+                Button {
+                    ImageController.shared.copyToPrompt(sdi)
+                } label: {
+                    Text(
+                        "Copy Options to Sidebar",
+                        comment: "Copy image's generation options to the prompt input sidebar"
+                    )
+                }
+
+                Button {
+                    Task { await ImageController.shared.selectStartingImage(sdi: sdi) }
+                } label: {
+                    Text("Set as Starting Image")
+                }
+            }
+            Section {
+                if sdi.upscaler.isEmpty {
+                    Button {
+                        Task { await ImageController.shared.upscale(sdi) }
+                    } label: {
+                        Text(
+                            "Convert to High Resolution",
+                            comment: "Convert image to high resolution"
+                        )
+                    }
+                }
+
+                Button {
+                    Task { await sdi.saveAs() }
+                } label: {
+                    Text(
+                        "Save As...",
+                        comment: "Show the save image dialog"
+                    )
+                }
+
+                if !sdi.path.isEmpty {
+                    Button {
+                        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: sdi.path).absoluteURL])
+                    } label: {
+                        Text(
+                            "Show in Finder",
+                            comment: "Show image with Finder"
+                        )
+                    }
+                }
+            }
+            Section {
+                Button {
+                    Task { await ImageController.shared.removeImage(sdi) }
+                } label: {
+                    Text(
+                        "Remove",
+                        comment: "Remove image from the gallery"
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/Mochi Diffusion/Views/GalleryView.swift
+++ b/Mochi Diffusion/Views/GalleryView.swift
@@ -11,15 +11,17 @@ struct GalleryView: View {
 
     @Environment(\.colorScheme) private var colorScheme
 
-    @EnvironmentObject private var generator: ImageGenerator
+    @EnvironmentObject private var controller: ImageController
     @EnvironmentObject private var store: ImageStore
 
     private let gridColumns = [GridItem(.adaptive(minimum: 200), spacing: 16)]
 
     var body: some View {
         VStack(spacing: 0) {
-            if case let .error(msg) = generator.state {
-                ErrorBanner(errorMessage: msg)
+            if case let .error(msg) = controller.state {
+                MessageBanner(message: msg)
+            } else if case let .ready(msg) = controller.state, let msg = msg {
+                MessageBanner(message: msg)
             }
 
             if !store.images.isEmpty {
@@ -118,8 +120,8 @@ struct GalleryView: View {
                     Text("Set as Starting Image")
                 }
             }
-            Section {
-                if sdi.upscaler.isEmpty {
+            if sdi.upscaler.isEmpty {
+                Section {
                     Button {
                         Task { await ImageController.shared.upscale(sdi) }
                     } label: {
@@ -129,7 +131,8 @@ struct GalleryView: View {
                         )
                     }
                 }
-
+            }
+            Section {
                 Button {
                     Task { await sdi.saveAs() }
                 } label: {

--- a/Mochi Diffusion/Views/MessageBanner.swift
+++ b/Mochi Diffusion/Views/MessageBanner.swift
@@ -1,5 +1,5 @@
 //
-//  ErrorBanner.swift
+//  MessageBanner.swift
 //  Mochi Diffusion
 //
 //  Created by Joshua Park on 12/17/2022.
@@ -7,11 +7,11 @@
 
 import SwiftUI
 
-struct ErrorBanner: View {
-    var errorMessage: String
+struct MessageBanner: View {
+    var message: String
 
     var body: some View {
-        Text(errorMessage)
+        Text(message)
             .font(.headline)
             .padding(4)
             .frame(maxWidth: .infinity)
@@ -19,8 +19,8 @@ struct ErrorBanner: View {
     }
 }
 
-struct ErrorBanner_Previews: PreviewProvider {
+struct MessageBanner_Previews: PreviewProvider {
     static var previews: some View {
-        ErrorBanner(errorMessage: "Hello error!")
+        MessageBanner(message: "Hello world!")
     }
 }

--- a/Mochi Diffusion/Views/SidebarControls/PromptView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/PromptView.swift
@@ -77,7 +77,6 @@ struct PromptTextEditor: View {
 
 struct PromptView: View {
     @EnvironmentObject private var controller: ImageController
-    @EnvironmentObject private var generator: ImageGenerator
     @EnvironmentObject private var focusCon: FocusController
 
     var body: some View {
@@ -115,7 +114,7 @@ struct PromptView: View {
 
                 Spacer()
 
-                if case .running = generator.state {
+                if case .running = controller.state {
                     Button {
                         Task { await ImageGenerator.shared.stopGenerate() }
                     } label: {
@@ -144,6 +143,6 @@ struct PromptView_Previews: PreviewProvider {
     static var previews: some View {
         PromptView()
             .environmentObject(ImageController.shared)
-            .environmentObject(ImageGenerator.shared)
+            .environmentObject(FocusController.shared)
     }
 }

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -37,12 +37,17 @@ struct ImageView: View {
 
 struct StartingImageView: View {
     @EnvironmentObject private var controller: ImageController
+    @State private var isInfoPopoverShown = false
 
     var body: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading) {
-                Text("Starting Image")
-                    .sidebarLabelFormat()
+                Text(
+                    "Starting Image",
+                    comment: "Label for setting the starting image (commonly known as image2image)"
+                )
+                .sidebarLabelFormat()
+
                 ImageView(image: $controller.startingImage)
                     .frame(height: 80)
             }
@@ -50,22 +55,47 @@ struct StartingImageView: View {
             Spacer()
 
             VStack(alignment: .trailing) {
-                Text("Strength")
-                    .sidebarLabelFormat()
-                Slider(value: $controller.strength, in: 0...1, step: 0.1)
-                    .controlSize(.mini)
-                    .frame(width: 85)
+                Text(
+                    "Strength",
+                    comment: "Label for image2image strength slider control"
+                )
+                .sidebarLabelFormat()
 
-                Button {
-                    Task { await ImageController.shared.selectStartingImage() }
-                } label: {
-                    Text("Select")
+                Slider(value: $controller.strength, in: 0.1...1, step: 0.1)
+                    .controlSize(.mini)
+                    .frame(width: 88)
+
+                HStack {
+                    Button {
+                        Task { await ImageController.shared.selectStartingImage() }
+                    } label: {
+                        Image(systemName: "photo")
+                    }
+
+                    Button {
+                        Task { await ImageController.shared.unsetStartingImage() }
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
                 }
 
+                Spacer()
+
                 Button {
-                    Task { await ImageController.shared.unsetStartingImage() }
+                    self.isInfoPopoverShown.toggle()
                 } label: {
-                    Text("Clear")
+                    Image(systemName: "info.circle")
+                        .foregroundColor(Color.secondary)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .popover(isPresented: self.$isInfoPopoverShown, arrowEdge: .top) {
+                    Text(
+                    """
+                    Use the same model along with **Copy Options to Sidebar** to get similar images.
+                    Note that the starting image size must match the size of the image that will be generated.
+                    """
+                    )
+                    .padding()
                 }
             }
         }

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -1,0 +1,80 @@
+//
+//  StartingImageView.swift
+//  Mochi Diffusion
+//
+//  Created by Joshua Park on 2/27/23.
+//
+
+import CompactSlider
+import SwiftUI
+
+struct ImageView: View {
+    @Binding var image: CGImage?
+
+    var body: some View {
+        if let image = image {
+            Image(image, scale: 1, label: Text(verbatim: ""))
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .padding(4)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 2)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                )
+        } else {
+            Image(systemName: "photo")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .foregroundColor(Color(nsColor: .separatorColor))
+                .padding(30)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 2)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                )
+        }
+    }
+}
+
+struct StartingImageView: View {
+    @EnvironmentObject private var controller: ImageController
+
+    var body: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading) {
+                Text("Starting Image")
+                    .sidebarLabelFormat()
+                ImageView(image: $controller.startingImage)
+                    .frame(height: 80)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing) {
+                Text("Strength")
+                    .sidebarLabelFormat()
+                Slider(value: $controller.strength, in: 0...1, step: 0.1)
+                    .controlSize(.mini)
+                    .frame(width: 85)
+
+                Button {
+                    Task { await ImageController.shared.selectStartingImage() }
+                } label: {
+                    Text("Select")
+                }
+
+                Button {
+                    Task { await ImageController.shared.unsetStartingImage() }
+                } label: {
+                    Text("Clear")
+                }
+            }
+        }
+    }
+}
+
+struct StartingImageView_Previews: PreviewProvider {
+    static var previews: some View {
+        StartingImageView()
+            .environmentObject(ImageController.shared)
+    }
+}

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -49,7 +49,7 @@ struct StartingImageView: View {
                 .sidebarLabelFormat()
 
                 ImageView(image: $controller.startingImage)
-                    .frame(height: 80)
+                    .frame(height: 90)
             }
 
             Spacer()
@@ -57,7 +57,7 @@ struct StartingImageView: View {
             VStack(alignment: .trailing) {
                 Text(
                     "Strength",
-                    comment: "Label for image2image strength slider control"
+                    comment: "Label for starting image strength slider control"
                 )
                 .sidebarLabelFormat()
 
@@ -91,8 +91,8 @@ struct StartingImageView: View {
                 .popover(isPresented: self.$isInfoPopoverShown, arrowEdge: .top) {
                     Text(
                     """
-                    Use the same model along with **Copy Options to Sidebar** to get similar images.
-                    Note that the starting image size must match the size of the image that will be generated.
+                    Use the same model and seed to get similar images.
+                    Note that the starting image must be 512x512.
                     """
                     )
                     .padding()

--- a/Mochi Diffusion/Views/SidebarView.swift
+++ b/Mochi Diffusion/Views/SidebarView.swift
@@ -16,6 +16,10 @@ struct SidebarView: View {
                     Divider().frame(height: 16)
                 }
                 Group {
+                    StartingImageView()
+                    Divider().frame(height: 16)
+                }
+                Group {
                     NumberOfImagesView()
                     Spacer().frame(height: 6)
                 }


### PR DESCRIPTION
Apple's library is very picky regarding the starting image size. It _must_ match the size of the image that will be generated or else it will fail. Also for some reason it currently only accepts images that are 512x512.

Resolves #151