### PR TITLE
Detect model type automatically

### DIFF
--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		03FD2319295F74B6006EEEE2 /* RealESRGAN.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 03FD2318295F74B6006EEEE2 /* RealESRGAN.mlmodel */; };
 		03FD231B295F7A81006EEEE2 /* Upscaler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FD231A295F7A81006EEEE2 /* Upscaler.swift */; };
 		9B7392C3298DEAC2006F03D5 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7392C2298DEAC2006F03D5 /* Tokenizer.swift */; };
+		D7B03F2029D42F9900DF89DD /* SDModelAttentionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B03F1F29D42F9900DF89DD /* SDModelAttentionType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -129,6 +130,7 @@
 		03FD2318295F74B6006EEEE2 /* RealESRGAN.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = RealESRGAN.mlmodel; sourceTree = "<group>"; };
 		03FD231A295F7A81006EEEE2 /* Upscaler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Upscaler.swift; sourceTree = "<group>"; };
 		9B7392C2298DEAC2006F03D5 /* Tokenizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
+		D7B03F1F29D42F9900DF89DD /* SDModelAttentionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDModelAttentionType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -271,6 +273,7 @@
 				0395B3102995C70400465B73 /* Scheduler.swift */,
 				03E89F3B294FE6ED0067457E /* SDImage.swift */,
 				03173C122999E2B500B03456 /* SDModel.swift */,
+				D7B03F1F29D42F9900DF89DD /* SDModelAttentionType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -502,6 +505,7 @@
 				035EE000295A224900080D18 /* ModelView.swift in Sources */,
 				03E075792968A153003488F9 /* CircularProgressView.swift in Sources */,
 				0352E2AA294EA0E1003FBF25 /* AppView.swift in Sources */,
+				D7B03F2029D42F9900DF89DD /* SDModelAttentionType.swift in Sources */,
 				0352E2B5294EA887003FBF25 /* Functions.swift in Sources */,
 				03173C132999E2B500B03456 /* SDModel.swift in Sources */,
 				0352E2B1294EA30D003FBF25 /* Extensions.swift in Sources */,

--- a/Mochi Diffusion/Model/SDModel.swift
+++ b/Mochi Diffusion/Model/SDModel.swift
@@ -7,6 +7,9 @@
 
 import CoreML
 import Foundation
+import os.log
+
+private let logger = Logger()
 
 struct SDModel: Identifiable, Hashable {
     let url: URL
@@ -43,6 +46,7 @@ private func identifyAttentionType(_ url: URL) -> SDModelAttentionType? {
 
         return metadatas[0].mlProgramOperationTypeHistogram["Ios16.einsum"] != nil ? .splitEinsum : .original
     } catch {
+        logger.warning("Failed to parse model metadata at '\(unetMetadataURL)': \(error)")
         return nil
     }
 }

--- a/Mochi Diffusion/Model/SDModel.swift
+++ b/Mochi Diffusion/Model/SDModel.swift
@@ -5,14 +5,44 @@
 //  Created by Joshua Park on 2/12/23.
 //
 
+import CoreML
 import Foundation
 
 struct SDModel: Identifiable, Hashable {
-    var id = UUID()
-    var url: URL
-    var name: String
+    let url: URL
+    let name: String
+    let attention: SDModelAttentionType
 
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(name)
+    var id: URL { url }
+
+    init?(url: URL, name: String) {
+        guard let attention = identifyAttentionType(url) else {
+            return nil
+        }
+
+        self.url = url
+        self.name = name
+        self.attention = attention
+    }
+}
+
+private func identifyAttentionType(_ url: URL) -> SDModelAttentionType? {
+    let unetMetadataURL = url.appending(components: "Unet.mlmodelc", "metadata.json")
+
+    struct ModelMetadata: Decodable {
+        let mlProgramOperationTypeHistogram: [String: Int]
+    }
+
+    do {
+        let jsonData = try Data(contentsOf: unetMetadataURL)
+        let metadatas = try JSONDecoder().decode([ModelMetadata].self, from: jsonData)
+
+        guard metadatas.count == 1 else {
+            return nil
+        }
+
+        return metadatas[0].mlProgramOperationTypeHistogram["Ios16.einsum"] != nil ? .splitEinsum : .original
+    } catch {
+        return nil
     }
 }

--- a/Mochi Diffusion/Model/SDModelAttentionType.swift
+++ b/Mochi Diffusion/Model/SDModelAttentionType.swift
@@ -1,0 +1,27 @@
+//
+//  SDModelAttentionType.swift
+//  Mochi Diffusion
+//
+//  Created by Váradi Zsolt on 2023. 03. 29..
+//
+
+import CoreML
+import Foundation
+
+enum SDModelAttentionType: Hashable, Equatable {
+    case splitEinsum
+    case original
+
+    var preferredComputeUnits: MLComputeUnits {
+        #if arch(arm64)
+        switch self {
+        case .original:
+            return .cpuAndGPU
+        case .splitEinsum:
+            return .cpuAndNeuralEngine
+        }
+        #else
+        return .cpuAndGPU
+        #endif
+    }
+}

--- a/Mochi Diffusion/Support/ImageGenerator.swift
+++ b/Mochi Diffusion/Support/ImageGenerator.swift
@@ -123,12 +123,9 @@ class ImageGenerator: ObservableObject {
         }
         do {
             let subDirs = try finalModelDirURL.subDirectories()
-            subDirs
+            models = subDirs
                 .sorted { $0.lastPathComponent.compare($1.lastPathComponent, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedAscending }
-                .forEach {
-                    let model = SDModel(url: $0, name: $0.lastPathComponent)
-                    models.append(model)
-                }
+                .compactMap { SDModel(url: $0, name: $0.lastPathComponent) }
         } catch {
             await updateState(.error("Could not get model subdirectories."))
             throw GeneratorError.modelSubDirectoriesNoAccess

--- a/Mochi Diffusion/Support/ImageGenerator.swift
+++ b/Mochi Diffusion/Support/ImageGenerator.swift
@@ -143,6 +143,7 @@ class ImageGenerator: ObservableObject {
             await updateState(.error("Couldn't load \(model.name) because it doesn't exist."))
             throw GeneratorError.requestedModelNotFound
         }
+        await updateState(.loading)
         let config = MLModelConfiguration()
         config.computeUnits = computeUnit
         self.pipeline = try StableDiffusionPipeline(

--- a/Mochi Diffusion/Views/SettingsView.swift
+++ b/Mochi Diffusion/Views/SettingsView.swift
@@ -205,37 +205,39 @@ struct SettingsView: View {
                 #if arch(arm64)
                 Divider()
 
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: 8) {
                     HStack {
                         Text("ML Compute Unit")
 
                         Spacer()
 
-                        Picker("", selection: $controller.mlComputeUnit) {
+                        Picker("", selection: $controller.mlComputeUnitPreference) {
+                            Text("Auto", comment: "Option to use the CPU + Neural Engine for split_einsum models, and CPU + GPU for original models")
+                                .tag(ComputeUnitPreference.auto)
                             Text("CPU & Neural Engine")
-                                .tag(MLComputeUnits.cpuAndNeuralEngine)
+                                .tag(ComputeUnitPreference.cpuAndNeuralEngine)
                             Text("CPU & GPU")
-                                .tag(MLComputeUnits.cpuAndGPU)
-                            Text(
-                                "All",
-                                comment: "Option to use all CPU, GPU, & Neural Engine for compute unit"
-                            )
-                            .tag(MLComputeUnits.all)
+                                .tag(ComputeUnitPreference.cpuAndGPU)
+                            Text("All", comment: "Option to use all CPU, GPU, & Neural Engine for compute unit")
+                                .tag(ComputeUnitPreference.all)
                         }
                         .labelsHidden()
                         .fixedSize()
                     }
-                    Text("CPU & Neural Engine provides a good balance between speed and low memory usage.")
+
+                    Text("**CPU & Neural Engine** provides a good balance between speed and low memory usage, but the Neural Engine is only compatible with split-einsum models.", comment: "Explanation for the 'CPU & NE' ML Compute Unit option")
                         .helpTextFormat()
 
-                    Text("CPU & GPU may be faster on M1 Max, Ultra and later but will use more memory.")
+                    Text("**CPU & GPU** is compatible with all models and may be faster on M1 Max, Ultra and later, but will use more memory.", comment: "Explanation for the 'CPU & GPU' ML Compute Unit option")
                         .helpTextFormat()
 
-                    Text(
-                        "Based on the option selected the correct model version will need to be used.",
-                        comment: "Help text for ML Compute Unit setting"
-                    )
-                    .helpTextFormat()
+                    Text("**Auto** selects the most appropriate configuration for the selected model.", comment: "Explanation for the 'Auto' ML Compute Unit option")
+                        .helpTextFormat()
+
+                    Divider()
+
+                    Text("Manually selecting an incompatible ML Compute Unit may lead to low performance and potentially crashes.")
+                        .helpTextFormat()
                 }
                 .padding(4)
                 #endif

--- a/Mochi Diffusion/Views/SidebarControls/ModelView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ModelView.swift
@@ -10,67 +10,17 @@ import SwiftUI
 
 struct ModelView: View {
     @EnvironmentObject private var controller: ImageController
-    #if arch(arm64)
-    @State private var isShowingComputeUnitPopover = false
-    #endif
 
     var body: some View {
         Text("Model")
             .sidebarLabelFormat()
         HStack {
-            Picker("", selection: $controller.currentModel.onChange(modelChanged)) {
+            Picker("", selection: $controller.currentModel) {
                 ForEach(controller.models) { model in
                     Text(verbatim: model.name).tag(Optional(model))
                 }
             }
             .labelsHidden()
-            #if arch(arm64)
-            .popover(isPresented: $isShowingComputeUnitPopover, arrowEdge: .top) {
-                VStack(alignment: .leading, spacing: 0) {
-                    Text("Select Compute Unit option")
-                        .fontWeight(.bold)
-
-                    Spacer()
-
-                    Text(
-                        "\(controller.currentModel!.name) model",
-                        comment: "Label displaying the currently selected model name"
-                    )
-
-                    Spacer()
-
-                    Text("For `split_einsum` models, select Use Neural Engine.")
-                        .helpTextFormat()
-                    Text("For `original` models, select Use GPU.")
-                        .helpTextFormat()
-
-                    Spacer()
-
-                    HStack {
-                        Button {
-                            Task {
-                                ImageController.shared.mlComputeUnit = .cpuAndNeuralEngine
-                                await ImageController.shared.loadModels()
-                                isShowingComputeUnitPopover = false
-                            }
-                        } label: {
-                            Text("Use Neural Engine")
-                        }
-
-                        Button {
-                            Task {
-                                ImageController.shared.mlComputeUnit = .cpuAndGPU
-                                await ImageController.shared.loadModels()
-                                isShowingComputeUnitPopover = false
-                            }
-                        } label: {
-                            Text("Use GPU")
-                        }
-                    }
-                }
-                .padding()
-            }
-            #endif
 
             Button {
                 Task { await ImageController.shared.loadModels() }
@@ -79,12 +29,6 @@ struct ModelView: View {
                     .frame(minWidth: 18)
             }
         }
-    }
-
-    func modelChanged(to value: SDModel?) {
-        #if arch(arm64)
-        isShowingComputeUnitPopover.toggle()
-        #endif
     }
 }
 


### PR DESCRIPTION
I had a flash of inspiration yesterday, and found a way to distinguish original/split-einsum models without introducing custom JSONs or anything extra into/around the models.

This renders the unit selection popover unnecessary too, so I dropped that and introduced a new setting as the "compute unit preference", replacing the previous, directly set MLComputeUnits. The default for everyone is Auto, but advanced users can force a specific unit in Settings/Image as before. Help labels are updated to match.

Fixes #193 and #170 (since the offending popover and race condition is gone).

(And I found a fun race condition when selecting a new model and pressing Generate twice causing two images to be rendered at the same time, but there's no open issue for it.)