### PR TITLE
Add ControlNet

### DIFF
--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		030370312A2BECDD003D2F0C /* ControlNet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030370302A2BECDD003D2F0C /* ControlNet.swift */; };
 		03061E6229AB9C06009AA2A2 /* FocusController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03061E6129AB9C06009AA2A2 /* FocusController.swift */; };
 		0307B0DA294D4AE500A9BD55 /* FileCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0307B0D9294D4AE500A9BD55 /* FileCommands.swift */; };
 		0311C69929899A660074BCAE /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0311C69829899A660074BCAE /* Metadata.swift */; };
@@ -74,6 +75,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		030370302A2BECDD003D2F0C /* ControlNet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlNet.swift; sourceTree = "<group>"; };
 		03061E6129AB9C06009AA2A2 /* FocusController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusController.swift; sourceTree = "<group>"; };
 		0307B0D9294D4AE500A9BD55 /* FileCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCommands.swift; sourceTree = "<group>"; };
 		0311C69829899A660074BCAE /* Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 		0386DF8E29510D8700CA4CEB /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				030370302A2BECDD003D2F0C /* ControlNet.swift */,
 				03173C17299B3C1300B03456 /* ImageStore.swift */,
 				0311C69829899A660074BCAE /* Metadata.swift */,
 				0395B3102995C70400465B73 /* Scheduler.swift */,
@@ -502,6 +505,7 @@
 				0395B3112995C70400465B73 /* Scheduler.swift in Sources */,
 				0352E2AE294EA2B4003FBF25 /* MessageBanner.swift in Sources */,
 				0386DF8B2950D29400CA4CEB /* InspectorView.swift in Sources */,
+				030370312A2BECDD003D2F0C /* ControlNet.swift in Sources */,
 				0373FF5429A9165600C0180F /* AppCommands.swift in Sources */,
 				03D280F2294FD60E00C7D184 /* PromptView.swift in Sources */,
 				03FD2319295F74B6006EEEE2 /* RealESRGAN.mlmodel in Sources */,

--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		03F578642967CE9A003A815F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 03F578622967CE9A003A815F /* Localizable.strings */; };
 		03FD2319295F74B6006EEEE2 /* RealESRGAN.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 03FD2318295F74B6006EEEE2 /* RealESRGAN.mlmodel */; };
 		03FD231B295F7A81006EEEE2 /* Upscaler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FD231A295F7A81006EEEE2 /* Upscaler.swift */; };
+		58FF218829FAE96200A70C7C /* ControlNetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FF218729FAE96200A70C7C /* ControlNetView.swift */; };
 		9B7392C3298DEAC2006F03D5 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7392C2298DEAC2006F03D5 /* Tokenizer.swift */; };
 		D7B03F2029D42F9900DF89DD /* SDModelAttentionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B03F1F29D42F9900DF89DD /* SDModelAttentionType.swift */; };
 /* End PBXBuildFile section */
@@ -129,6 +130,7 @@
 		03F75CEC2979B3910071CD1C /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		03FD2318295F74B6006EEEE2 /* RealESRGAN.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = RealESRGAN.mlmodel; sourceTree = "<group>"; };
 		03FD231A295F7A81006EEEE2 /* Upscaler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Upscaler.swift; sourceTree = "<group>"; };
+		58FF218729FAE96200A70C7C /* ControlNetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlNetView.swift; sourceTree = "<group>"; };
 		9B7392C2298DEAC2006F03D5 /* Tokenizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
 		D7B03F1F29D42F9900DF89DD /* SDModelAttentionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDModelAttentionType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -199,6 +201,7 @@
 				035EDFF9295A219200080D18 /* GuidanceScaleView.swift */,
 				035EDFFD295A220F00080D18 /* SeedView.swift */,
 				035EDFFF295A224900080D18 /* ModelView.swift */,
+				58FF218729FAE96200A70C7C /* ControlNetView.swift */,
 				035EDFFB295A21D600080D18 /* SizeView.swift */,
 			);
 			path = SidebarControls;
@@ -504,6 +507,7 @@
 				03FD2319295F74B6006EEEE2 /* RealESRGAN.mlmodel in Sources */,
 				035EE000295A224900080D18 /* ModelView.swift in Sources */,
 				03E075792968A153003488F9 /* CircularProgressView.swift in Sources */,
+				58FF218829FAE96200A70C7C /* ControlNetView.swift in Sources */,
 				0352E2AA294EA0E1003FBF25 /* AppView.swift in Sources */,
 				D7B03F2029D42F9900DF89DD /* SDModelAttentionType.swift in Sources */,
 				0352E2B5294EA887003FBF25 /* Functions.swift in Sources */,

--- a/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/apple/ml-stable-diffusion",
       "state" : {
         "branch" : "main",
-        "revision" : "fbef6c38264f5a9cbb9c2d344d4b5eb811f916f6"
+        "revision" : "4aafa737bae229b1757b4795dac9e6f618d8c6aa"
       }
     },
     {

--- a/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/apple/ml-stable-diffusion",
       "state" : {
         "branch" : "main",
-        "revision" : "ef5aa89c4515d11a30d4561cae1952bfb4321bd8"
+        "revision" : "ea904e31d7553f93739da9197dd40dd81ea17ab2"
       }
     },
     {

--- a/Mochi Diffusion/Model/ControlNet.swift
+++ b/Mochi Diffusion/Model/ControlNet.swift
@@ -1,0 +1,14 @@
+//
+//  ControlNet.swift
+//  Mochi Diffusion
+//
+//  Created by Stuart Moore on 6/3/23.
+//
+
+import CoreGraphics
+import Foundation
+
+struct ControlNet {
+    var name: String?
+    var image: CGImage?
+}

--- a/Mochi Diffusion/Model/SDModel.swift
+++ b/Mochi Diffusion/Model/SDModel.swift
@@ -19,7 +19,7 @@ struct SDModel: Identifiable, Hashable {
 
     var id: URL { url }
 
-    init?(url: URL, name: String) {
+    init?(url: URL, name: String, controlNet: [String]) {
         guard let attention = identifyAttentionType(url) else {
             return nil
         }
@@ -27,19 +27,8 @@ struct SDModel: Identifiable, Hashable {
         self.url = url
         self.name = name
         self.attention = attention
-        self.controlNet = controlNets(url)
+        self.controlNet = controlNet
     }
-}
-
-private func controlNets(_ url: URL) -> [String] {
-    let controlNetSymLinkPath = url.appending(component: "controlnet").path(percentEncoded: false)
-
-    guard FileManager.default.fileExists(atPath: controlNetSymLinkPath),
-        let contentsOfControlNet = try? FileManager.default.contentsOfDirectory(atPath: controlNetSymLinkPath) else {
-        return []
-    }
-
-    return contentsOfControlNet.filter { !$0.hasPrefix(".") }.map { $0.replacing(".mlmodelc", with: "") }
 }
 
 private func identifyAttentionType(_ url: URL) -> SDModelAttentionType? {

--- a/Mochi Diffusion/Model/SDModel.swift
+++ b/Mochi Diffusion/Model/SDModel.swift
@@ -32,10 +32,10 @@ struct SDModel: Identifiable, Hashable {
 }
 
 private func controlNets(_ url: URL) -> [String] {
-    let controlNetSymLink = url.appending(component: "controlnet")
+    let controlNetSymLinkPath = url.appending(component: "controlnet").path(percentEncoded: false)
 
-    guard FileManager.default.fileExists(atPath: controlNetSymLink.path()),
-        let contentsOfControlNet = try? FileManager.default.contentsOfDirectory(atPath: controlNetSymLink.path()) else {
+    guard FileManager.default.fileExists(atPath: controlNetSymLinkPath),
+        let contentsOfControlNet = try? FileManager.default.contentsOfDirectory(atPath: controlNetSymLinkPath) else {
         return []
     }
 

--- a/Mochi Diffusion/Model/SDModel.swift
+++ b/Mochi Diffusion/Model/SDModel.swift
@@ -35,7 +35,7 @@ private func controlNets(_ url: URL) -> [String] {
     let controlNetSymLink = url.appending(component: "controlnet")
 
     guard FileManager.default.fileExists(atPath: controlNetSymLink.path()),
-          let contentsOfControlNet = try? FileManager.default.contentsOfDirectory(atPath: controlNetSymLink.path()) else {
+        let contentsOfControlNet = try? FileManager.default.contentsOfDirectory(atPath: controlNetSymLink.path()) else {
         return []
     }
 

--- a/Mochi Diffusion/Model/SDModel.swift
+++ b/Mochi Diffusion/Model/SDModel.swift
@@ -48,7 +48,7 @@ private func identifyAttentionType(_ url: URL) -> SDModelAttentionType? {
 
     let metadataURL: URL
 
-    if FileManager.default.fileExists(atPath: unetMetadataURL.path()) {
+    if FileManager.default.fileExists(atPath: unetMetadataURL.path(percentEncoded: false)) {
         metadataURL = unetMetadataURL
     } else {
         metadataURL = controlledUnetMetadataURL

--- a/Mochi Diffusion/Model/SDModel.swift
+++ b/Mochi Diffusion/Model/SDModel.swift
@@ -15,6 +15,7 @@ struct SDModel: Identifiable, Hashable {
     let url: URL
     let name: String
     let attention: SDModelAttentionType
+    let controlNet: [String]
 
     var id: URL { url }
 
@@ -26,18 +27,39 @@ struct SDModel: Identifiable, Hashable {
         self.url = url
         self.name = name
         self.attention = attention
+        self.controlNet = controlNets(url)
     }
+}
+
+private func controlNets(_ url: URL) -> [String] {
+    let controlNetSymLink = url.appending(component: "controlnet")
+
+    guard FileManager.default.fileExists(atPath: controlNetSymLink.path()),
+          let contentsOfControlNet = try? FileManager.default.contentsOfDirectory(atPath: controlNetSymLink.path()) else {
+        return []
+    }
+
+    return contentsOfControlNet.filter { !$0.hasPrefix(".") }.map { $0.replacing(".mlmodelc", with: "") }
 }
 
 private func identifyAttentionType(_ url: URL) -> SDModelAttentionType? {
     let unetMetadataURL = url.appending(components: "Unet.mlmodelc", "metadata.json")
+    let controlledUnetMetadataURL = url.appending(components: "ControlledUnet.mlmodelc", "metadata.json")
+
+    let metadataURL: URL
+
+    if FileManager.default.fileExists(atPath: unetMetadataURL.path()) {
+        metadataURL = unetMetadataURL
+    } else {
+        metadataURL = controlledUnetMetadataURL
+    }
 
     struct ModelMetadata: Decodable {
         let mlProgramOperationTypeHistogram: [String: Int]
     }
 
     do {
-        let jsonData = try Data(contentsOf: unetMetadataURL)
+        let jsonData = try Data(contentsOf: metadataURL)
         let metadatas = try JSONDecoder().decode([ModelMetadata].self, from: jsonData)
 
         guard metadatas.count == 1 else {
@@ -46,7 +68,7 @@ private func identifyAttentionType(_ url: URL) -> SDModelAttentionType? {
 
         return metadatas[0].mlProgramOperationTypeHistogram["Ios16.einsum"] != nil ? .splitEinsum : .original
     } catch {
-        logger.warning("Failed to parse model metadata at '\(unetMetadataURL)': \(error)")
+        logger.warning("Failed to parse model metadata at '\(metadataURL)': \(error)")
         return nil
     }
 }

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -97,7 +97,7 @@ final class ImageController: ObservableObject {
     }
 
     @Published
-    var currentControlNet: String? { // TODO: Use array
+    var currentControlNet: String? {
         didSet {
             reloadModel()
         }
@@ -388,7 +388,7 @@ final class ImageController: ObservableObject {
     }
 
     func unsetControlNetImage(_ image: CGImage) async {
-        controlNetImages.removeAll(where: { $0 == image })
+        controlNetImages.removeAll { $0 == image }
     }
 
     func importImages() async {

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -94,7 +94,7 @@ final class ImageController: ObservableObject {
     }
 
     @Published
-    var currentControlNets: [(String, CGImage?)] = [] {
+    var currentControlNets: [(String?, CGImage?)] = [] {
         didSet {
             reloadModel()
         }
@@ -110,7 +110,7 @@ final class ImageController: ObservableObject {
             do {
                 try await ImageGenerator.shared.load(
                     model: model,
-                    controlNet: currentControlNets.filter { $1 != nil }.map(\.0),
+                    controlNet: currentControlNets.filter { $0.1 != nil }.compactMap(\.0),
                     computeUnit: mlComputeUnitPreference.computeUnits(forModel: model),
                     reduceMemory: reduceMemory
                 )
@@ -252,7 +252,7 @@ final class ImageController: ObservableObject {
         pipelineConfig.guidanceScale = Float(guidanceScale)
         pipelineConfig.disableSafety = !safetyChecker
         pipelineConfig.schedulerType = convertScheduler(scheduler)
-        pipelineConfig.controlNetInputs = currentControlNets.compactMap(\.1)
+        pipelineConfig.controlNetInputs = currentControlNets.filter { $0.0 != nil }.compactMap(\.1)
 
         let genConfig = GenerationConfig(
             pipelineConfig: pipelineConfig,

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -90,14 +90,14 @@ final class ImageController: ObservableObject {
 
             modelName = model.name
             controlNet = model.controlNet
-            currentControlNet = model.controlNet.first
+            currentControlNets = []
 
             reloadModel()
         }
     }
 
     @Published
-    var currentControlNet: String? {
+    var currentControlNets: [String] = [] {
         didSet {
             reloadModel()
         }
@@ -113,7 +113,7 @@ final class ImageController: ObservableObject {
             do {
                 try await ImageGenerator.shared.load(
                     model: model,
-                    controlNet: currentControlNet.map { [$0] } ?? [],
+                    controlNet: currentControlNets,
                     computeUnit: mlComputeUnitPreference.computeUnits(forModel: model),
                     reduceMemory: reduceMemory
                 )
@@ -123,12 +123,12 @@ final class ImageController: ObservableObject {
                 modelName = ""
                 currentModel = nil
                 controlNet = []
-                currentControlNet = nil
+                currentControlNets = []
             } catch {
                 modelName = ""
                 currentModel = nil
                 controlNet = []
-                currentControlNet = nil
+                currentControlNets = []
             }
         }
     }

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -131,6 +131,7 @@ final class ImageController: ObservableObject {
     }
 
     @AppStorage("ModelDir") var modelDir = ""
+    @AppStorage("ControlNetDir") var controlNetDir = ""
     @AppStorage("Model") private(set) var modelName = ""
     @AppStorage("AutosaveImages") var autosaveImages = true
     @AppStorage("ImageDir") var imageDir = ""
@@ -189,9 +190,10 @@ final class ImageController: ObservableObject {
         models = []
         logger.info("Started loading model directory at: \"\(self.modelDir)\"")
         do {
-            async let (foundModels, modelDirURL) = try ImageGenerator.shared.getModels(modelDir: modelDir)
+            async let (foundModels, modelDirURL, controlNetDirURL) = try ImageGenerator.shared.getModels(modelDir: modelDir, controlNetDir: controlNetDir)
             try await self.models = foundModels
             try await self.modelDir = modelDirURL.path(percentEncoded: false)
+            try await self.controlNetDir = controlNetDirURL.path(percentEncoded: false)
 
             logger.info("Found \(self.models.count) model(s)")
 

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -94,7 +94,7 @@ final class ImageController: ObservableObject {
     }
 
     @Published
-    var currentControlNets: [(String?, CGImage?)] = [] {
+    var currentControlNets: [ControlNet] = [] {
         didSet {
             loadModel()
         }
@@ -110,7 +110,7 @@ final class ImageController: ObservableObject {
             do {
                 try await ImageGenerator.shared.load(
                     model: model,
-                    controlNet: currentControlNets.filter { $0.1 != nil }.compactMap(\.0),
+                    controlNet: currentControlNets.filter { $0.image != nil }.compactMap(\.name),
                     computeUnit: mlComputeUnitPreference.computeUnits(forModel: model),
                     reduceMemory: reduceMemory
                 )
@@ -252,7 +252,7 @@ final class ImageController: ObservableObject {
         pipelineConfig.guidanceScale = Float(guidanceScale)
         pipelineConfig.disableSafety = !safetyChecker
         pipelineConfig.schedulerType = convertScheduler(scheduler)
-        pipelineConfig.controlNetInputs = currentControlNets.filter { $0.0 != nil }.compactMap(\.1)
+        pipelineConfig.controlNetInputs = currentControlNets.filter { $0.name != nil }.compactMap(\.image)
 
         let genConfig = GenerationConfig(
             pipelineConfig: pipelineConfig,
@@ -374,11 +374,11 @@ final class ImageController: ObservableObject {
     func selectControlNetImage(at index: Int) async {
         await selectImage(title: "ControlNet").map { image in
             if currentControlNets.isEmpty {
-                currentControlNets = [(nil, image)]
+                currentControlNets = [ControlNet(image: image)]
             } else if index >= currentControlNets.count {
-                currentControlNets.append((nil, image))
+                currentControlNets.append(ControlNet(image: image))
             } else {
-                currentControlNets[index].1 = image
+                currentControlNets[index].image = image
             }
         }
     }
@@ -414,7 +414,7 @@ final class ImageController: ObservableObject {
     }
 
     func unsetControlNetImage(at index: Int) async {
-        currentControlNets[index].1 = nil
+        currentControlNets[index].image = nil
     }
 
     func importImages() async {

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -372,7 +372,15 @@ final class ImageController: ObservableObject {
     }
 
     func selectControlNetImage(at index: Int) async {
-        await selectImage(title: "ControlNet").map { currentControlNets[index].1 = $0 }
+        await selectImage(title: "ControlNet").map { image in
+            if currentControlNets.isEmpty {
+                currentControlNets = [(nil, image)]
+            } else if index >= currentControlNets.count {
+                currentControlNets.append((nil, image))
+            } else {
+                currentControlNets[index].1 = image
+            }
+        }
     }
 
     func selectImage(title: String) async -> CGImage? {

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -89,18 +89,18 @@ final class ImageController: ObservableObject {
             controlNet = model.controlNet
             currentControlNets = []
 
-            reloadModel()
+            loadModel()
         }
     }
 
     @Published
     var currentControlNets: [(String?, CGImage?)] = [] {
         didSet {
-            reloadModel()
+            loadModel()
         }
     }
 
-    private func reloadModel() {
+    private func loadModel() {
         guard let model = currentModel else {
             return
         }

--- a/Mochi Diffusion/Support/ImageGenerator.swift
+++ b/Mochi Diffusion/Support/ImageGenerator.swift
@@ -129,7 +129,7 @@ class ImageGenerator: ObservableObject {
         return (models, finalModelDirURL)
     }
 
-    func load(model: SDModel, computeUnit: MLComputeUnits, reduceMemory: Bool) async throws {
+    func load(model: SDModel, controlNet: [String] = [], computeUnit: MLComputeUnits, reduceMemory: Bool) async throws {
         let fm = FileManager.default
         if !fm.fileExists(atPath: model.url.path) {
             await updateState(.error("Couldn't load \(model.name) because it doesn't exist."))
@@ -138,9 +138,10 @@ class ImageGenerator: ObservableObject {
         await updateState(.loading)
         let config = MLModelConfiguration()
         config.computeUnits = computeUnit
+
         self.pipeline = try StableDiffusionPipeline(
             resourcesAt: model.url,
-            controlNet: [],
+            controlNet: controlNet,
             configuration: config,
             disableSafety: true,
             reduceMemory: reduceMemory

--- a/Mochi Diffusion/Views/SettingsView.swift
+++ b/Mochi Diffusion/Views/SettingsView.swift
@@ -141,6 +141,28 @@ struct SettingsView: View {
 
             GroupBox {
                 VStack(alignment: .leading) {
+                    Text("ControlNet Folder")
+
+                    HStack {
+                        TextField("", text: $controller.controlNetDir)
+                            .disableAutocorrection(true)
+                            .textFieldStyle(.roundedBorder)
+
+                        Button {
+                            NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: controller.controlNetDir).absoluteURL])
+                        } label: {
+                            Image(systemName: "magnifyingglass.circle.fill")
+                                .foregroundColor(Color.secondary)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .help("Open in Finder")
+                    }
+                }
+                .padding(4)
+            }
+
+            GroupBox {
+                VStack(alignment: .leading) {
                     HStack {
                         Text("Move Images to Trash")
 

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -36,6 +36,7 @@ struct ControlNetView: View {
                                 .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
                         )
                         .frame(height: 90)
+                        .accessibilityAddTraits(.isButton)
                         .onTapGesture {
                             Task { await ImageController.shared.unsetControlNetImage(image) }
                         }
@@ -51,6 +52,7 @@ struct ControlNetView: View {
                             .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
                     )
                     .frame(height: 90)
+                    .accessibilityAddTraits(.isButton)
                     .onTapGesture {
                         Task { await ImageController.shared.selectControlNetImage() }
                     }

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -18,14 +18,36 @@ struct ControlNetView: View {
         if controller.controlNet.isEmpty {
             Text("N/A")
         } else {
-            Picker("", selection: $controller.currentControlNet) {
-                Text(verbatim: "None").tag(Optional<String>.none)
-
+            Menu {
                 ForEach(controller.controlNet, id: \.self) { name in
-                    Text(verbatim: name).tag(Optional(name))
+                    Button {
+                        if let index = controller.currentControlNets.firstIndex(of: name) {
+                            controller.currentControlNets.remove(at: index)
+                        } else {
+                            controller.currentControlNets.append(name)
+                        }
+                    } label: {
+                        if controller.currentControlNets.contains(name) {
+                            Image(systemName: "checkmark")
+                        }
+                        Text(verbatim: name)
+                    }
+                }
+
+                Divider()
+
+                Button {
+                    controller.currentControlNets = []
+                } label: {
+                    Text(verbatim: "Clear All")
+                }
+            } label: {
+                if controller.currentControlNets.isEmpty {
+                    Text("None")
+                } else {
+                    Text(controller.currentControlNets.formatted(.list(type: .and)))
                 }
             }
-            .labelsHidden()
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -71,6 +71,7 @@ struct ControlNetView: View {
                         }
                 }
                 .buttonStyle(.plain)
+                .disabled(controller.controlNet.isEmpty)
             }
 
             Spacer()
@@ -105,6 +106,7 @@ struct ControlNetView: View {
                         Text("None")
                     }
                 }
+                .disabled(controller.controlNet.isEmpty)
 
                 HStack {
                     Button {
@@ -112,12 +114,14 @@ struct ControlNetView: View {
                     } label: {
                         Image(systemName: "photo")
                     }
+                    .disabled(controller.controlNet.isEmpty)
 
                     Button {
                         Task { await ImageController.shared.unsetControlNetImage(at: 0) }
                     } label: {
                         Image(systemName: "xmark")
                     }
+                    .disabled(controller.controlNet.isEmpty)
                 }
             }
         }

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -38,6 +38,7 @@ struct ControlNetView: View {
 
                 Button {
                     controller.currentControlNets = []
+                    controller.controlNetImages = []
                 } label: {
                     Text(verbatim: "Clear All")
                 }

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -15,94 +15,118 @@ struct ControlNetView: View {
         Text("ControlNet")
             .sidebarLabelFormat()
 
-        Menu {
-            Button {
-                controller.currentControlNets = []
-            } label: {
-                Text("None")
-            }
-
-            Divider()
-
-            if !controller.controlNet.isEmpty {
-                ForEach(controller.controlNet, id: \.self) { name in
+        HStack(alignment: .top) {
+            if let image = controller.currentControlNets.first?.image {
+                ZStack(alignment: .topTrailing) {
+                    Image(image, scale: 1, label: Text(verbatim: ""))
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .padding(3)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 2)
+                                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                        )
+                        .frame(height: 90)
+                        .accessibilityAddTraits(.isButton)
                     Button {
-                        if controller.currentControlNets.isEmpty {
-                            controller.currentControlNets = [(name, nil)]
-                        } else {
-                            controller.currentControlNets[0].0 = name
-                        }
+                        Task { await ImageController.shared.unsetControlNetImage(at: 0) }
                     } label: {
-                        Text(verbatim: name)
+                        Image(systemName: "xmark.circle.fill")
                     }
                 }
-            }
-        } label: {
-            if let name = controller.currentControlNets.first?.0 {
-                Text(name)
             } else {
-                Text("None")
-            }
-        }
+                Button {
+                    Task { await ImageController.shared.selectControlNetImage(at: 0) }
+                } label: {
+                    Image(systemName: "photo")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .foregroundColor(Color(nsColor: .separatorColor))
+                        .padding(30)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 2)
+                                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                        )
+                        .background(.background.opacity(0.01))
+                        .frame(height: 90)
+                        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+                            _ = providers.first?.loadDataRepresentation(for: .fileURL) { data, _ in
+                                guard let data, let urlString = String(data: data, encoding: .utf8), let url = URL(string: urlString) else {
+                                    return
+                                }
 
-        if let image = controller.currentControlNets.first?.1 {
-            Image(image, scale: 1, label: Text(verbatim: ""))
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .padding(3)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 2)
-                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                )
-                .frame(height: 90)
-                .accessibilityAddTraits(.isButton)
-                .onTapGesture {
-                    Task { await ImageController.shared.unsetControlNetImage(at: 0) }
-                }
-        } else {
-            Button {
-                Task { await ImageController.shared.selectControlNetImage(at: 0) }
-            } label: {
-                Image(systemName: "photo")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .foregroundColor(Color(nsColor: .separatorColor))
-                    .padding(30)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 2)
-                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                    )
-                    .background(.background.opacity(0.01))
-                    .frame(height: 90)
-                    .onDrop(of: [.fileURL], isTargeted: nil) { providers in
-                        _ = providers.first?.loadDataRepresentation(for: .fileURL) { data, _ in
-                            guard let data, let urlString = String(data: data, encoding: .utf8), let url = URL(string: urlString) else {
-                                return
-                            }
+                                guard let cgImageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+                                    return
+                                }
 
-                            guard let cgImageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
-                                return
-                            }
+                                let imageIndex = CGImageSourceGetPrimaryImageIndex(cgImageSource)
 
-                            let imageIndex = CGImageSourceGetPrimaryImageIndex(cgImageSource)
+                                guard let cgImage = CGImageSourceCreateImageAtIndex(cgImageSource, imageIndex, nil) else {
+                                    return
+                                }
 
-                            guard let cgImage = CGImageSourceCreateImageAtIndex(cgImageSource, imageIndex, nil) else {
-                                return
-                            }
-
-                            DispatchQueue.main.async {
-                                if controller.currentControlNets.isEmpty {
-                                    controller.currentControlNets = [(nil, cgImage)]
-                                } else {
-                                    controller.currentControlNets[0].1 = cgImage
+                                DispatchQueue.main.async {
+                                    if controller.currentControlNets.isEmpty {
+                                        controller.currentControlNets = [ControlNet(image: cgImage)]
+                                    } else {
+                                        controller.currentControlNets[0].image = cgImage
+                                    }
                                 }
                             }
-                        }
 
-                        return true
-                    }
+                            return true
+                        }
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
+
+            Spacer()
+
+            VStack(alignment: .trailing) {
+                Menu {
+                    Button {
+                        controller.currentControlNets = []
+                    } label: {
+                        Text("None")
+                    }
+
+                    Divider()
+
+                    if !controller.controlNet.isEmpty {
+                        ForEach(controller.controlNet, id: \.self) { name in
+                            Button {
+                                if controller.currentControlNets.isEmpty {
+                                    controller.currentControlNets = [ControlNet(name: name)]
+                                } else {
+                                    controller.currentControlNets[0].name = name
+                                }
+                            } label: {
+                                Text(verbatim: name)
+                            }
+                        }
+                    }
+                } label: {
+                    if let name = controller.currentControlNets.first?.name {
+                        Text(name)
+                    } else {
+                        Text("None")
+                    }
+                }
+
+                HStack {
+                    Button {
+                        Task { await ImageController.shared.selectControlNetImage(at: 0) }
+                    } label: {
+                        Image(systemName: "photo")
+                    }
+
+                    Button {
+                        Task { await ImageController.shared.unsetControlNetImage(at: 0) }
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                }
+            }
         }
     }
 }

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -17,23 +17,16 @@ struct ControlNetView: View {
 
         HStack(alignment: .top) {
             if let image = controller.currentControlNets.first?.image {
-                ZStack(alignment: .topTrailing) {
-                    Image(image, scale: 1, label: Text(verbatim: ""))
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .padding(3)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 2)
-                                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                        )
-                        .frame(height: 90)
-                        .accessibilityAddTraits(.isButton)
-                    Button {
-                        Task { await ImageController.shared.unsetControlNetImage(at: 0) }
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                    }
-                }
+                Image(image, scale: 1, label: Text(verbatim: ""))
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .padding(3)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 2)
+                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                    )
+                    .frame(height: 90)
+                    .accessibilityAddTraits(.isButton)
             } else {
                 Button {
                     Task { await ImageController.shared.selectControlNetImage(at: 0) }

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -24,9 +24,7 @@ struct ControlNetView: View {
 
             Divider()
 
-            if controller.controlNet.isEmpty {
-                Text("No ControlNet models found")
-            } else {
+            if !controller.controlNet.isEmpty {
                 ForEach(controller.controlNet, id: \.self) { name in
                     Button {
                         if controller.currentControlNets.isEmpty {

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -1,0 +1,67 @@
+//
+//  ControlNetView.swift
+//  Mochi Diffusion
+//
+//  Created by Stuart Moore on 4/27/23.
+//
+
+import CoreML
+import SwiftUI
+
+struct ControlNetView: View {
+    @EnvironmentObject private var controller: ImageController
+
+    var body: some View {
+        Text("ControlNet")
+            .sidebarLabelFormat()
+
+        if controller.controlNet.isEmpty {
+            Text("N/A")
+        } else {
+            Picker("", selection: $controller.currentControlNet) {
+                ForEach(controller.controlNet, id: \.self) { name in
+                    Text(verbatim: name).tag(Optional(name))
+                }
+            }
+            .labelsHidden()
+
+            HStack(alignment: .top) {
+                ForEach(controller.controlNetImages, id: \.self) { image in
+                    Image(image, scale: 1, label: Text(verbatim: ""))
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .padding(3)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 2)
+                                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                        )
+                        .frame(height: 90)
+                        .onTapGesture {
+                            Task { await ImageController.shared.unsetControlNetImage(image) }
+                        }
+                }
+
+                Image(systemName: "photo")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .foregroundColor(Color(nsColor: .separatorColor))
+                    .padding(30)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 2)
+                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                    )
+                    .frame(height: 90)
+                    .onTapGesture {
+                        Task { await ImageController.shared.selectControlNetImage() }
+                    }
+            }
+        }
+    }
+}
+
+struct ControlNetView_Previews: PreviewProvider {
+    static var previews: some View {
+        ControlNetView()
+            .environmentObject(ImageController.shared)
+    }
+}

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -19,6 +19,8 @@ struct ControlNetView: View {
             Text("N/A")
         } else {
             Picker("", selection: $controller.currentControlNet) {
+                Text(verbatim: "None").tag(Optional<String>.none)
+
                 ForEach(controller.controlNet, id: \.self) { name in
                     Text(verbatim: name).tag(Optional(name))
                 }

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -16,7 +16,7 @@ struct ControlNetView: View {
             .sidebarLabelFormat()
 
         if controller.controlNet.isEmpty {
-            Text("N/A")
+            Text("No ControlNet model found.")
         } else {
             ForEach(Array(controller.currentControlNets.enumerated()), id: \.offset) { index, currentControlNet in
                 Menu {

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -27,37 +27,41 @@ struct ControlNetView: View {
             }
             .labelsHidden()
 
-            HStack(alignment: .top) {
-                ForEach(controller.controlNetImages, id: \.self) { image in
-                    Image(image, scale: 1, label: Text(verbatim: ""))
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .padding(3)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 2)
-                                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                        )
-                        .frame(height: 90)
-                        .accessibilityAddTraits(.isButton)
-                        .onTapGesture {
-                            Task { await ImageController.shared.unsetControlNetImage(image) }
-                        }
-                }
-
-                Image(systemName: "photo")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .foregroundColor(Color(nsColor: .separatorColor))
-                    .padding(30)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 2)
-                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                    )
-                    .frame(height: 90)
-                    .accessibilityAddTraits(.isButton)
-                    .onTapGesture {
-                        Task { await ImageController.shared.selectControlNetImage() }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack {
+                    ForEach(controller.controlNetImages, id: \.self) { image in
+                        Image(image, scale: 1, label: Text(verbatim: ""))
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .padding(3)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 2)
+                                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                            )
+                            .frame(height: 90)
+                            .accessibilityAddTraits(.isButton)
+                            .onTapGesture {
+                                Task { await ImageController.shared.unsetControlNetImage(image) }
+                            }
                     }
+
+                    Button {
+                        Task { await ImageController.shared.selectControlNetImage() }
+                    } label: {
+                        Image(systemName: "photo")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .foregroundColor(Color(nsColor: .separatorColor))
+                            .padding(30)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 2)
+                                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                            )
+                            .background(.background.opacity(0.01))
+                            .frame(height: 90)
+                    }
+                    .buttonStyle(.plain)
+                }
             }
         }
     }

--- a/Mochi Diffusion/Views/SidebarControls/PromptView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/PromptView.swift
@@ -131,7 +131,7 @@ struct PromptView: View {
                             comment: "Button to generate image"
                         )
                     }
-                    .disabled(controller.modelName.isEmpty) // TODO: Require image(s) for ControlNet
+                    .disabled(controller.modelName.isEmpty)
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
                 }

--- a/Mochi Diffusion/Views/SidebarControls/PromptView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/PromptView.swift
@@ -131,7 +131,7 @@ struct PromptView: View {
                             comment: "Button to generate image"
                         )
                     }
-                    .disabled(controller.modelName.isEmpty)
+                    .disabled(controller.modelName.isEmpty) // TODO: Require image(s) for ControlNet
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
                 }

--- a/Mochi Diffusion/Views/SidebarView.swift
+++ b/Mochi Diffusion/Views/SidebarView.swift
@@ -20,10 +20,6 @@ struct SidebarView: View {
                     Divider().frame(height: 16)
                 }
                 Group {
-                    ControlNetView()
-                    Divider().frame(height: 16)
-                }
-                Group {
                     NumberOfImagesView()
                     Spacer().frame(height: 6)
                 }
@@ -41,6 +37,10 @@ struct SidebarView: View {
                 }
                 Group {
                     ModelView()
+                    Divider().frame(height: 16)
+                }
+                Group {
+                    ControlNetView()
                 }
             }
             .padding([.horizontal, .bottom])

--- a/Mochi Diffusion/Views/SidebarView.swift
+++ b/Mochi Diffusion/Views/SidebarView.swift
@@ -20,6 +20,10 @@ struct SidebarView: View {
                     Divider().frame(height: 16)
                 }
                 Group {
+                    ControlNetView()
+                    Divider().frame(height: 16)
+                }
+                Group {
                     NumberOfImagesView()
                     Spacer().frame(height: 6)
                 }


### PR DESCRIPTION
Adds the ability to use a ControlNet model with an accompanying image.

## Screenshots
<img width="245" alt="Screenshot 2023-06-03 at 3 54 55 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/642708/d099b794-34d4-46e4-a3f4-dc7b9e4ada52">
<img width="244" alt="Screenshot 2023-06-03 at 3 55 06 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/642708/9d98ceca-ea1a-475a-bee5-1677ed1c0736">
<img width="243" alt="Screenshot 2023-06-03 at 3 55 13 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/642708/de2f2085-ab64-4588-a7a5-baca378ca933">
<img width="244" alt="Screenshot 2023-06-03 at 3 58 36 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/642708/9ed8c9ab-f4a5-4553-b456-315c4a07b056">
