### PR TITLE
Remove support for Intel Macs

### DIFF
--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -708,7 +708,7 @@
 		036BFC44294B9F7600D8AD04 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Mochi Diffusion/App.entitlements";
@@ -741,7 +741,7 @@
 		036BFC45294B9F7600D8AD04 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Mochi Diffusion/App.entitlements";

--- a/Mochi Diffusion/Model/SDModelAttentionType.swift
+++ b/Mochi Diffusion/Model/SDModelAttentionType.swift
@@ -13,15 +13,11 @@ enum SDModelAttentionType: Hashable, Equatable {
     case original
 
     var preferredComputeUnits: MLComputeUnits {
-        #if arch(arm64)
         switch self {
         case .original:
             return .cpuAndGPU
         case .splitEinsum:
             return .cpuAndNeuralEngine
         }
-        #else
-        return .cpuAndGPU
-        #endif
     }
 }

--- a/Mochi Diffusion/Views/SettingsView.swift
+++ b/Mochi Diffusion/Views/SettingsView.swift
@@ -202,7 +202,6 @@ struct SettingsView: View {
                 }
                 .padding(4)
 
-                #if arch(arm64)
                 Divider()
 
                 VStack(alignment: .leading, spacing: 8) {
@@ -249,7 +248,6 @@ struct SettingsView: View {
                         .helpTextFormat()
                 }
                 .padding(4)
-                #endif
             }
 
             GroupBox {


### PR DESCRIPTION
Apple doesn't seem to be interested in fixing Stable Diffusion Core ML for Intel Macs so unfortunately we have to drop support.