### PR TITLE
Starting Image: Change strength value range

### DIFF
--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -91,9 +91,9 @@ struct StartingImageView: View {
                 .popover(isPresented: self.$isInfoPopoverShown, arrowEdge: .top) {
                     Text(
                     """
-                    Strength controls how closely the generated image resembles the starting image vs following the text prompt.
-                    Use lower values to generate images that look more like the starting image.
-                    Use higher values to generate images that more closely follow the text prompt.
+                    Strength controls how closely the generated image resembles the starting image.
+                    Use lower values to generate images that look similar to the starting image.
+                    Use higher values to allow more creative freedom.
 
                     The size of the starting image must match the output image size of the current model.
                     """

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -61,7 +61,7 @@ struct StartingImageView: View {
                 )
                 .sidebarLabelFormat()
 
-                Slider(value: $controller.strength, in: 0.1...1, step: 0.1)
+                Slider(value: $controller.strength, in: 0.685...1, step: 0.035)
                     .controlSize(.mini)
                     .frame(width: 88)
 
@@ -91,9 +91,9 @@ struct StartingImageView: View {
                 .popover(isPresented: self.$isInfoPopoverShown, arrowEdge: .top) {
                     Text(
                     """
-                    Strength controls how closely the generated image resembles the starting image.
-                    Use lower values to generate images that look similar to the starting image.
-                    Use higher values to allow more creative freedom.
+                    Strength controls how closely the generated image resembles the starting image vs following the text prompt.
+                    Use lower values to generate images that look more like the starting image.
+                    Use higher values to generate images that more closely follow the text prompt.
 
                     The size of the starting image must match the output image size of the current model.
                     """


### PR DESCRIPTION
This PR changes the range of the "STARTING IMAGE" "STRENGTH" slider to 0.645 - 1.000 in 10 increments of 0.035.  This range more closely tracks the effective range of "STRENGTH" changes to the generated image.

This PR also revises the info text for "STARTING IMAGE" to try to more accurately reflect the function of the strength slider in the i2i pipeline.