### PR TITLE
feat: Enable inpainting with the InPaint ControlNet

### DIFF
--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -40,7 +40,6 @@
 		0386DF8D2950F25500CA4CEB /* GalleryToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0386DF8C2950F25500CA4CEB /* GalleryToolbarView.swift */; };
 		0388DEB0297B00FC008B1C1C /* CompactSlider in Frameworks */ = {isa = PBXBuildFile; productRef = 0388DEAF297B00FC008B1C1C /* CompactSlider */; };
 		0395B3112995C70400465B73 /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0395B3102995C70400465B73 /* Scheduler.swift */; };
-		03ADC8B9299581AF00B2843F /* StableDiffusion in Frameworks */ = {isa = PBXBuildFile; productRef = 03ADC8B8299581AF00B2843F /* StableDiffusion */; };
 		03B1ACA8295167B900302F54 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B1ACA7295167B900302F54 /* SettingsView.swift */; };
 		03CB9D18297399AE0041A4FA /* ImageCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CB9D17297399AE0041A4FA /* ImageCommands.swift */; };
 		03D280F2294FD60E00C7D184 /* PromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D280F1294FD60E00C7D184 /* PromptView.swift */; };
@@ -54,6 +53,7 @@
 		03FD231B295F7A81006EEEE2 /* Upscaler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FD231A295F7A81006EEEE2 /* Upscaler.swift */; };
 		58FF218829FAE96200A70C7C /* ControlNetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FF218729FAE96200A70C7C /* ControlNetView.swift */; };
 		9B7392C3298DEAC2006F03D5 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7392C2298DEAC2006F03D5 /* Tokenizer.swift */; };
+		D72004C92A571AE00034C80D /* StableDiffusion in Frameworks */ = {isa = PBXBuildFile; productRef = D72004C82A571AE00034C80D /* StableDiffusion */; };
 		D7B03F2029D42F9900DF89DD /* SDModelAttentionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B03F1F29D42F9900DF89DD /* SDModelAttentionType.swift */; };
 /* End PBXBuildFile section */
 
@@ -124,7 +124,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				036BFC4E294B9FDB00D8AD04 /* Path in Frameworks */,
-				03ADC8B9299581AF00B2843F /* StableDiffusion in Frameworks */,
+				D72004C92A571AE00034C80D /* StableDiffusion in Frameworks */,
 				0352E2A5294E2591003FBF25 /* Sparkle in Frameworks */,
 				0388DEB0297B00FC008B1C1C /* CompactSlider in Frameworks */,
 			);
@@ -279,7 +279,7 @@
 				036BFC4D294B9FDB00D8AD04 /* Path */,
 				0352E2A4294E2591003FBF25 /* Sparkle */,
 				0388DEAF297B00FC008B1C1C /* CompactSlider */,
-				03ADC8B8299581AF00B2843F /* StableDiffusion */,
+				D72004C82A571AE00034C80D /* StableDiffusion */,
 			);
 			productName = "Mochi Diffusion";
 			productReference = 036BFC1E294B9F7500D8AD04 /* Mochi Diffusion.app */;
@@ -348,7 +348,7 @@
 				036BFC4C294B9FDB00D8AD04 /* XCRemoteSwiftPackageReference "Path.swift" */,
 				0352E2A3294E2591003FBF25 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				0388DEAE297B00FC008B1C1C /* XCRemoteSwiftPackageReference "CompactSlider" */,
-				03ADC8B7299581AF00B2843F /* XCRemoteSwiftPackageReference "ml-stable-diffusion" */,
+				D72004C72A571AE00034C80D /* XCRemoteSwiftPackageReference "ml-stable-diffusion" */,
 			);
 			productRefGroup = 036BFC1F294B9F7500D8AD04 /* Products */;
 			projectDirPath = "";
@@ -711,11 +711,11 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		03ADC8B7299581AF00B2843F /* XCRemoteSwiftPackageReference "ml-stable-diffusion" */ = {
+		D72004C72A571AE00034C80D /* XCRemoteSwiftPackageReference "ml-stable-diffusion" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/apple/ml-stable-diffusion";
+			repositoryURL = "https://github.com/vzsg/ml-stable-diffusion";
 			requirement = {
-				branch = main;
+				branch = "controlnet-inpaint";
 				kind = branch;
 			};
 		};
@@ -737,9 +737,9 @@
 			package = 0388DEAE297B00FC008B1C1C /* XCRemoteSwiftPackageReference "CompactSlider" */;
 			productName = CompactSlider;
 		};
-		03ADC8B8299581AF00B2843F /* StableDiffusion */ = {
+		D72004C82A571AE00034C80D /* StableDiffusion */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 03ADC8B7299581AF00B2843F /* XCRemoteSwiftPackageReference "ml-stable-diffusion" */;
+			package = D72004C72A571AE00034C80D /* XCRemoteSwiftPackageReference "ml-stable-diffusion" */;
 			productName = StableDiffusion;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/vzsg/ml-stable-diffusion",
       "state" : {
         "branch" : "controlnet-inpaint",
-        "revision" : "fccfeba780d043324827105d3056858d1b60e90c"
+        "revision" : "c44c51d4bc6711d996fbdb9e5493162a1de50df1"
       }
     },
     {

--- a/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,10 +12,10 @@
     {
       "identity" : "ml-stable-diffusion",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/ml-stable-diffusion",
+      "location" : "https://github.com/vzsg/ml-stable-diffusion",
       "state" : {
-        "branch" : "main",
-        "revision" : "e3875a584b173774357c76beda659df9f62527ec"
+        "branch" : "controlnet-inpaint",
+        "revision" : "fccfeba780d043324827105d3056858d1b60e90c"
       }
     },
     {


### PR DESCRIPTION
For this to work, I replaced the ml-stable-diffusion/main dependency with [my fork](https://github.com/vzsg/ml-stable-diffusion/tree/controlnet-inpaint), on a safe branch that was split off from 0.4.0, the last old Xcode-friendly version.

Related: #197, #207.

## Usage

1. Get a ControlNet-capable (`_cn` suffix) model, e.g. [coreml-ghostmix-v20-bakedVAE_cn](https://huggingface.co/coreml/coreml-ghostmix-v20-bakedVAE_cn)
2. Get the InPaint ControlNet model from [ControlNet-Models-For-Core-ML](https://huggingface.co/coreml/ControlNet-Models-For-Core-ML/tree/main/CN), regular or **S**plit**E**insum as you like.
3. Generate or gather an image of the correct size that will be the control image.
4. Open the image in Preview (or an actual image editor), and erase the parts you want infilled to transparent.
5. Save as PNG to keep the alpha channel.
6. Select the models, select this image in Controlnet, adjust prompts if needed, and generate an image.

<img width="361" alt="image" src="https://github.com/godly-devotion/MochiDiffusion/assets/1783465/b406a234-b16d-439c-876a-ce1a04115cb9">


## Example output

|Starting image|CN image (with transparent hole)|Result|
|-|-|-|
|![bald man with round face and a goatee sitting at coffee table, camo pa 4225211956 copy](https://github.com/godly-devotion/MochiDiffusion/assets/1783465/24249944-4e2b-48c6-80f5-6d47e76fa833)|![bald man masked transparent](https://github.com/godly-devotion/MochiDiffusion/assets/1783465/7590c4e2-75fd-445a-a4cc-852b98305538)|![image](https://github.com/godly-devotion/MochiDiffusion/assets/1783465/3cea42b5-96ff-4f85-bda1-dbb1f7bcef8d)|