### PR TITLE
fix: Fix crash when CN image unset button is tapped without an active CN

### DIFF
--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -414,6 +414,7 @@ final class ImageController: ObservableObject {
     }
 
     func unsetControlNetImage(at index: Int) async {
+        guard index < currentControlNets.count else { return }
         currentControlNets[index].image = nil
     }
 


### PR DESCRIPTION
A rather trivial fix for a crash that occured when a CN-compatible model was selected, and the X button was tapped.