### PR TITLE
feat: Sorting by creation date for gallery

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -145,7 +145,8 @@ redundant_void_return: error
 return_arrow_whitespace: error
 self_in_property_initialization: error
 shorthand_operator: error
-sorted_imports: error
+sorted_imports:
+  severity: error
 statement_position:
   severity: error
 switch_case_alignment:

--- a/Mochi Diffusion/Model/ImageStore.swift
+++ b/Mochi Diffusion/Model/ImageStore.swift
@@ -8,6 +8,13 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+enum ImagesSortType: String {
+    case oldestFirst = "Oldest First"
+    case newestFirst = "Newest First"
+
+    static let allValues: [ImagesSortType] = [.oldestFirst, .newestFirst]
+}
+
 @MainActor
 class ImageStore: ObservableObject {
 
@@ -33,7 +40,7 @@ class ImageStore: ObservableObject {
         }
     }
 
-    @Published var sortType: ImagesSortType = .oldest {
+    @Published var sortType: ImagesSortType = .oldestFirst {
         didSet {
             updateSortForImages()
         }
@@ -151,19 +158,12 @@ class ImageStore: ObservableObject {
 
     private func updateSortForImages() {
         switch sortType {
-        case .oldest:
+        case .oldestFirst:
             images.sort(by: { $0.generatedDate < $1.generatedDate })
-        case.newest:
+        case.newestFirst:
             images.sort(by: { $0.generatedDate > $1.generatedDate })
         }
     }
-}
-
-enum ImagesSortType: String {
-    case oldest = "Oldest"
-    case newest = "Newest"
-
-    static let allValues: [ImagesSortType] = [.oldest, .newest]
 }
 
 private extension Array where Element == SDImage {

--- a/Mochi Diffusion/Model/ImageStore.swift
+++ b/Mochi Diffusion/Model/ImageStore.swift
@@ -33,7 +33,7 @@ class ImageStore: ObservableObject {
         }
     }
 
-    @Published var sortType: ImagesSortType = .ascending {
+    @Published var sortType: ImagesSortType = .oldest {
         didSet {
             updateSortForImages()
         }
@@ -151,19 +151,19 @@ class ImageStore: ObservableObject {
 
     private func updateSortForImages() {
         switch sortType {
-        case .ascending:
+        case .oldest:
             images.sort(by: { $0.generatedDate < $1.generatedDate })
-        case.decending:
+        case.newest:
             images.sort(by: { $0.generatedDate > $1.generatedDate })
         }
     }
 }
 
 enum ImagesSortType: String {
-    case ascending = "Accending"
-    case decending = "Decending"
+    case oldest = "Oldest"
+    case newest = "Newest"
 
-    static let allValues: [ImagesSortType] = [.ascending, .decending]
+    static let allValues: [ImagesSortType] = [.oldest, .newest]
 }
 
 private extension Array where Element == SDImage {

--- a/Mochi Diffusion/Model/ImageStore.swift
+++ b/Mochi Diffusion/Model/ImageStore.swift
@@ -16,6 +16,7 @@ class ImageStore: ObservableObject {
     private var allImages: [SDImage] = [] {
         didSet {
             updateFilteredImages()
+            updateSortForImages()
         }
     }
 
@@ -29,6 +30,12 @@ class ImageStore: ObservableObject {
     var searchText: String = "" {
         didSet {
             updateFilteredImages()
+        }
+    }
+
+    @Published var sortType: ImagesSortType = .ascending {
+        didSet {
+            updateSortForImages()
         }
     }
 
@@ -141,6 +148,22 @@ class ImageStore: ObservableObject {
             }
         }
     }
+
+    private func updateSortForImages() {
+        switch sortType {
+        case .ascending:
+            images.sort(by: { $0.generatedDate < $1.generatedDate })
+        case.decending:
+            images.sort(by: { $0.generatedDate > $1.generatedDate })
+        }
+    }
+}
+
+enum ImagesSortType: String {
+    case ascending = "Accending"
+    case decending = "Decending"
+
+    static let allValues: [ImagesSortType] = [.ascending, .decending]
 }
 
 private extension Array where Element == SDImage {

--- a/Mochi Diffusion/Views/GalleryToolbarView.swift
+++ b/Mochi Diffusion/Views/GalleryToolbarView.swift
@@ -65,7 +65,7 @@ struct GalleryToolbarView: View {
             }
         }
 
-        Picker("Sort: ", selection: $store.sortType) {
+        Picker("Sort", selection: $store.sortType) {
             ForEach(ImagesSortType.allValues, id: \.self) { sortType in
                 Text(verbatim: sortType.rawValue)
             }

--- a/Mochi Diffusion/Views/GalleryToolbarView.swift
+++ b/Mochi Diffusion/Views/GalleryToolbarView.swift
@@ -65,6 +65,12 @@ struct GalleryToolbarView: View {
             }
         }
 
+        Picker("Sort: ", selection: $store.sortType) {
+            ForEach(ImagesSortType.allValues, id: \.self) { sortType in
+                Text(verbatim: sortType.rawValue)
+            }
+        }
+
         if let sdi = store.selected(), let img = sdi.image {
             let imageView = Image(img, scale: 1, label: Text(verbatim: sdi.prompt))
 


### PR DESCRIPTION
In this PR i have added sorting functionality to the gallery, allowing users to sort images by their creation date.
Implemented options for both ascending and descending sorting orders.
This feature enhances the user experience by providing more control and flexibility in navigating through the gallery. Users can now easily organize and explore images based on their creation dates.

Please review the changes and consider merging them into the main branch.

Also fixes: #271 

Thank you!