### PR TITLE
Update packages

### DIFF
--- a/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/apple/ml-stable-diffusion",
       "state" : {
         "branch" : "main",
-        "revision" : "e3875a584b173774357c76beda659df9f62527ec"
+        "revision" : "db13060fec870361755fb0ce80e019727bcda2ec"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "7907f058bcef1132c9b4af6c049cac598330a5f9",
-        "version" : "2.4.1"
+        "revision" : "87e4fcbac39912f9cdb9a9acf205cad60e1ca3bc",
+        "version" : "2.4.2"
       }
     },
     {


### PR DESCRIPTION
Now that inpainting and Xcode 14 compatibility are merged into upstream, my ml-stable-diffusion fork is no longer required. Instead, all it takes is just a version bump.

---

Obsoletes #272.
Fixes #197 and fixes #207.