### PR TITLE
Sidebar & Strength Slider Mods

### DIFF
--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -43,7 +43,7 @@ struct StartingImageView: View {
         HStack(alignment: .top) {
             VStack(alignment: .leading) {
                 Text(
-                    "Starting Image",
+                    "Input Image",
                     comment: "Label for setting the starting image (commonly known as image2image)"
                 )
                 .sidebarLabelFormat()
@@ -61,9 +61,9 @@ struct StartingImageView: View {
                 )
                 .sidebarLabelFormat()
 
-                Slider(value: $controller.strength, in: 0.685...1, step: 0.035)
+                Slider(value: $controller.strength, in: 0.37...1, step: 0.07)
                     .controlSize(.mini)
-                    .frame(width: 88)
+                    .frame(width: 110)
 
                 HStack {
                     Button {

--- a/Mochi Diffusion/Views/SidebarView.swift
+++ b/Mochi Diffusion/Views/SidebarView.swift
@@ -13,11 +13,11 @@ struct SidebarView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Group {
                     PromptView()
-                    Divider().frame(height: 16)
+                    Divider().frame(height: 20)
                 }
                 Group {
-                    StartingImageView()
-                    Divider().frame(height: 16)
+                    ModelView()
+                    Divider().frame(height: 24)
                 }
                 Group {
                     NumberOfImagesView()
@@ -33,14 +33,15 @@ struct SidebarView: View {
                 }
                 Group {
                     SeedView()
-                    Spacer().frame(height: 6)
+                    Divider().frame(height: 20)
                 }
                 Group {
-                    ModelView()
-                    Divider().frame(height: 16)
+                    StartingImageView()
+                    Divider().frame(height: 24)
                 }
                 Group {
                     ControlNetView()
+                    Divider().frame(height: 24)
                 }
             }
             .padding([.horizontal, .bottom])


### PR DESCRIPTION
Reorder Sidebar Elements, Adjust Strength Slider Min. Value (Again)

1.  Set minimum value of Image2Image STRENGTH slider to 0.37 to allow for closer tracking of STARTING IMAGE.  Responding to:  https://github.com/godly-devotion/MochiDiffusion/issues/266 .  Also sets width of slider to match width of CONTROLNET dropdown when sidebar width is at minimum.  Perhaps there is a way to make it adjust automatically instead?

2.  Renames STARTING IMAGE to INPUT IMAGE   <------ personal preference

3.  Reorder sidebar items, tweak spacing   <------ personal preference

No offense taken if my "personal preferences" don't fit your vision for the UI.

![Screencap](https://github.com/godly-devotion/MochiDiffusion/assets/114269461/866caffa-3bcd-487a-9670-3814f5d6d59c)
