### PR TITLE
Sidebar & Slider Mods

### DIFF
--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -63,7 +63,7 @@ struct StartingImageView: View {
 
                 Slider(value: $controller.strength, in: 0.37...1, step: 0.07)
                     .controlSize(.mini)
-                    .frame(width: 110)
+                    .frame(maxWidth: .infinity)
 
                 HStack {
                     Button {

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -43,7 +43,7 @@ struct StartingImageView: View {
         HStack(alignment: .top) {
             VStack(alignment: .leading) {
                 Text(
-                    "Starting Image",
+                    "Input Image",
                     comment: "Label for setting the starting image (commonly known as image2image)"
                 )
                 .sidebarLabelFormat()
@@ -61,9 +61,9 @@ struct StartingImageView: View {
                 )
                 .sidebarLabelFormat()
 
-                Slider(value: $controller.strength, in: 0.685...1, step: 0.035)
+                Slider(value: $controller.strength, in: 0.37...1, step: 0.07)
                     .controlSize(.mini)
-                    .frame(width: 88)
+                    .frame(width: 110)
 
                 HStack {
                     Button {

--- a/Mochi Diffusion/Views/SidebarView.swift
+++ b/Mochi Diffusion/Views/SidebarView.swift
@@ -13,11 +13,11 @@ struct SidebarView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Group {
                     PromptView()
-                    Divider().frame(height: 16)
+                    Divider().frame(height: 20)
                 }
                 Group {
-                    StartingImageView()
-                    Divider().frame(height: 16)
+                    ModelView()
+                    Divider().frame(height: 24)
                 }
                 Group {
                     NumberOfImagesView()
@@ -33,14 +33,15 @@ struct SidebarView: View {
                 }
                 Group {
                     SeedView()
-                    Spacer().frame(height: 6)
+                    Divider().frame(height: 20)
                 }
                 Group {
-                    ModelView()
-                    Divider().frame(height: 16)
+                    StartingImageView()
+                    Divider().frame(height: 24)
                 }
                 Group {
                     ControlNetView()
+                    Divider().frame(height: 24)
                 }
             }
             .padding([.horizontal, .bottom])


### PR DESCRIPTION
This PR proposes the following changes:

1.  Adjust Image2Image STRENGTH slider minimum value down to 0.37 in response to https://github.com/godly-devotion/MochiDiffusion/issues/266

2.  Change STARTING IMAGE label to INPUT IMAGE   <---------- personal preference

3.  Reorder sidebar elements and tweak spacing.  Includes adjusting the length of the STRENGTH slider to match the length of the CONTROLNET drop down, when the sidebar is set at minimum width.  Probably it should "adjust to fill", as the drop down does, but I don't know how to code that.   (Updated it to auto-adjust, thanks to my friend ChatGPT.)   <---------- personal preference
 
No offense taken if my personal preferences don't sit well with your vision of the UI.

![Screencap](https://github.com/godly-devotion/MochiDiffusion/assets/114269461/3462e7bb-9907-4b8d-880f-6366510d42f2)