### PR TITLE
Use SDXL pipeline for XL models

### DIFF
--- a/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mochi Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,10 +12,10 @@
     {
       "identity" : "ml-stable-diffusion",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/ml-stable-diffusion",
+      "location" : "https://github.com/apple/ml-stable-diffusion.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b61c9aea05370d4bc06fce2dc00a002b21f13da5"
+        "revision" : "8cf34376f9faf87fc6fe63159e5fae6cbbb71de6"
       }
     },
     {

--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -51,7 +51,7 @@ extension NSImage {
     }
 }
 
-extension NSImage {
+extension NSImage: Transferable {
     private static var urlCache = [Int: URL]()
 
     public static var transferRepresentation: some TransferRepresentation {

--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -51,7 +51,7 @@ extension NSImage {
     }
 }
 
-extension NSImage: Transferable {
+extension NSImage {
     private static var urlCache = [Int: URL]()
 
     public static var transferRepresentation: some TransferRepresentation {

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -110,7 +110,7 @@ final class ImageController: ObservableObject {
                     computeUnit: mlComputeUnitPreference.computeUnits(forModel: model),
                     reduceMemory: reduceMemory
                 )
-                logger.info("Stable Diffusion pipeline successfully loaded")
+                logger.info("Stable Diffusion \(model.isXL ? "XL " : "")pipeline successfully loaded")
             } catch ImageGenerator.GeneratorError.requestedModelNotFound {
                 logger.error("Couldn't load \(self.modelName) because it doesn't exist.")
                 modelName = ""
@@ -269,7 +269,7 @@ final class ImageController: ObservableObject {
                 try await ImageGenerator.shared.generate(genConfig)
             } catch ImageGenerator.GeneratorError.pipelineNotAvailable {
                 await self.logger.error("Pipeline is not loaded.")
-            } catch StableDiffusionPipeline.Error.startingImageProvidedWithoutEncoder {
+            } catch PipelineError.startingImageProvidedWithoutEncoder {
                 await self.logger.error("The selected model does not support setting a starting image.")
                 await ImageGenerator.shared.updateState(.ready("The selected model does not support setting a starting image."))
             } catch Encoder.Error.sampleInputShapeNotCorrect {

--- a/Mochi Diffusion/Support/ImageGenerator.swift
+++ b/Mochi Diffusion/Support/ImageGenerator.swift
@@ -57,7 +57,7 @@ class ImageGenerator: ObservableObject {
     @Published
     private(set) var queueProgress = QueueProgress(index: 0, total: 0)
 
-    private var pipeline: StableDiffusionPipeline?
+    private var pipeline: (any StableDiffusionPipelineProtocol)?
 
     private(set) var tokenizer: Tokenizer?
 
@@ -152,13 +152,22 @@ class ImageGenerator: ObservableObject {
         let config = MLModelConfiguration()
         config.computeUnits = computeUnit
 
-        self.pipeline = try StableDiffusionPipeline(
-            resourcesAt: model.url,
-            controlNet: controlNet,
-            configuration: config,
-            disableSafety: true,
-            reduceMemory: reduceMemory
-        )
+        if model.isXL {
+            self.pipeline = try StableDiffusionXLPipeline(
+                resourcesAt: model.url,
+                configuration: config,
+                reduceMemory: reduceMemory
+            )
+        } else {
+            self.pipeline = try StableDiffusionPipeline(
+                resourcesAt: model.url,
+                controlNet: controlNet,
+                configuration: config,
+                disableSafety: true,
+                reduceMemory: reduceMemory
+            )
+        }
+
         self.tokenizer = Tokenizer(modelDir: model.url)
         await updateState(.ready(nil))
     }

--- a/Mochi Diffusion/Support/ImageGenerator.swift
+++ b/Mochi Diffusion/Support/ImageGenerator.swift
@@ -153,11 +153,16 @@ class ImageGenerator: ObservableObject {
         config.computeUnits = computeUnit
 
         if model.isXL {
-            self.pipeline = try StableDiffusionXLPipeline(
-                resourcesAt: model.url,
-                configuration: config,
-                reduceMemory: reduceMemory
-            )
+            if #available(macOS 14.0, *) {
+                self.pipeline = try StableDiffusionXLPipeline(
+                    resourcesAt: model.url,
+                    configuration: config,
+                    reduceMemory: reduceMemory
+                )
+            } else {
+                // Stable Diffusion XL requires macOS 14
+                throw GeneratorError.pipelineNotAvailable
+            }
         } else {
             self.pipeline = try StableDiffusionPipeline(
                 resourcesAt: model.url,


### PR DESCRIPTION
This PR just detects if the current model is an SDXL model using the presence of the new inputs `time_ids` and `text_embeds`, and uses the new pipeline `StableDiffusionXLPipeline` with the supported params. There still needs to be safety check and controlnet support, but that should happen upstream.

Just put one of these models in your model folder, and give it a try.
Normal: https://huggingface.co/apple/coreml-stable-diffusion-xl-base/blob/main/coreml-stable-diffusion-xl-base_original_compiled.zip
Palletized (Requires macOS 14): https://huggingface.co/apple/coreml-stable-diffusion-mixed-bit-palettization/blob/main/coreml-stable-diffusion-mixed-bit-palettization_original_compiled.zip