### PR TITLE
Fix transferable protocol on macOS 14

### DIFF
--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -61,6 +61,7 @@ extension TransferableImage: Transferable {
         if #available(macOS 14.0, *) {
             return NSImage.transferRepresentation
         } else {
+            // swiftlint:disable:next trailing_closure
             return ProxyRepresentation<TransferableImage, URL>(exporting: { (transferableImage: TransferableImage) in
                 return try transferableImage.image.temporaryFileURL()
             })

--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -63,8 +63,9 @@ extension TransferableImage: Transferable {
         } else {
             // swiftlint:disable:next trailing_closure
             return ProxyRepresentation<TransferableImage, URL>(exporting: { (transferableImage: TransferableImage) in
-                return try transferableImage.image.temporaryFileURL()
-            })
+                    return try transferableImage.image.temporaryFileURL()
+                }
+            )
         }
     }
 }

--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -58,15 +58,22 @@ public struct TransferableImage {
 
 extension TransferableImage: Transferable {
     public static var transferRepresentation: some TransferRepresentation {
+        #if swift(>=5.9)
         if #available(macOS 14.0, *) {
             return NSImage.transferRepresentation
         } else {
-            // swiftlint:disable:next trailing_closure
             return ProxyRepresentation<TransferableImage, URL>(exporting: { (transferableImage: TransferableImage) in
                     return try transferableImage.image.temporaryFileURL()
                 }
             )
         }
+        #else
+        // swiftlint:disable:next trailing_closure
+        return ProxyRepresentation<TransferableImage, URL>(exporting: { (transferableImage: TransferableImage) in
+                return try transferableImage.image.temporaryFileURL()
+            }
+        )
+        #endif
     }
 }
 

--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -62,9 +62,9 @@ extension TransferableImage: Transferable {
         if #available(macOS 14.0, *) {
             return NSImage.transferRepresentation
         } else {
-            return ProxyRepresentation<TransferableImage, URL>(exporting: { transferableImage in
+            return ProxyRepresentation<TransferableImage, URL> { transferableImage in
                 try transferableImage.image.temporaryFileURL()
-            })
+            }
         }
         #else
         return ProxyRepresentation<TransferableImage, URL> { transferableImage in

--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -62,18 +62,14 @@ extension TransferableImage: Transferable {
         if #available(macOS 14.0, *) {
             return NSImage.transferRepresentation
         } else {
-            return ProxyRepresentation<TransferableImage, URL>(
-                exporting: { transferableImage in
-                    try transferableImage.image.temporaryFileURL()
-                }
-            )
+            return ProxyRepresentation<TransferableImage, URL>(exporting: { transferableImage in
+                try transferableImage.image.temporaryFileURL()
+            })
         }
         #else
-        return ProxyRepresentation<TransferableImage, URL>(
-            exporting: { transferableImage in
-                try transferableImage.image.temporaryFileURL()
-            }
-        )
+        return ProxyRepresentation<TransferableImage, URL> { transferableImage in
+            try transferableImage.image.temporaryFileURL()
+        }
         #endif
     }
 }

--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -62,16 +62,16 @@ extension TransferableImage: Transferable {
         if #available(macOS 14.0, *) {
             return NSImage.transferRepresentation
         } else {
-            // swiftlint:disable:next trailing_closure
-            return ProxyRepresentation<TransferableImage, URL>(exporting: { (transferableImage: TransferableImage) in
-                    return try transferableImage.image.temporaryFileURL()
+            return ProxyRepresentation<TransferableImage, URL>(
+                exporting: { transferableImage in
+                    try transferableImage.image.temporaryFileURL()
                 }
             )
         }
         #else
-        // swiftlint:disable:next trailing_closure
-        return ProxyRepresentation<TransferableImage, URL>(exporting: { (transferableImage: TransferableImage) in
-                return try transferableImage.image.temporaryFileURL()
+        return ProxyRepresentation<TransferableImage, URL>(
+            exporting: { transferableImage in
+                try transferableImage.image.temporaryFileURL()
             }
         )
         #endif

--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -62,6 +62,7 @@ extension TransferableImage: Transferable {
         if #available(macOS 14.0, *) {
             return NSImage.transferRepresentation
         } else {
+            // swiftlint:disable:next trailing_closure
             return ProxyRepresentation<TransferableImage, URL>(exporting: { (transferableImage: TransferableImage) in
                     return try transferableImage.image.temporaryFileURL()
                 }

--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -51,33 +51,42 @@ extension NSImage {
     }
 }
 
-extension NSImage: Transferable {
+@available(macOS, introduced: 13.0, deprecated: 14.0)
+public struct TransferableImage {
+    public let image: NSImage
+}
+
+extension TransferableImage: Transferable {
+    public static var transferRepresentation: some TransferRepresentation {
+        if #available(macOS 14.0, *) {
+            return NSImage.transferRepresentation
+        } else {
+            return ProxyRepresentation<TransferableImage, URL>(exporting: { (transferableImage: TransferableImage) in
+                return try transferableImage.image.temporaryFileURL()
+            })
+        }
+    }
+}
+
+extension NSImage {
     private static var urlCache = [Int: URL]()
 
-    public static var transferRepresentation: some TransferRepresentation {
-        // swiftlint:disable:next trailing_closure
-        ProxyRepresentation<NSImage, URL>(exporting: { image in
-            let nsImage: NSImage = image
-            return try nsImage.temporaryFileURL()
-        })
-    }
-
     public static func cleanupTempFiles() {
-        for url in NSImage.urlCache {
+        for url in self.urlCache {
             try? FileManager.default.removeItem(at: url.value)
         }
     }
 
     func temporaryFileURL() throws -> URL {
         let imageHash = self.getImageHash()
-        if let cachedURL = NSImage.urlCache[imageHash] {
+        if let cachedURL = Self.urlCache[imageHash] {
             return cachedURL
         }
         let name = String(imageHash)
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(name, conformingTo: .png)
         let fileWrapper = FileWrapper(regularFileWithContents: self.toPngData())
         try fileWrapper.write(to: url, originalContentsURL: nil)
-        NSImage.urlCache[imageHash] = url
+        Self.urlCache[imageHash] = url
         return url
     }
 }

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -73,7 +73,7 @@ final class ImageController: ObservableObject {
     private var quicklookId: UUID? {
         didSet {
             quicklookURL = quicklookId.flatMap { id in
-                try? ImageStore.shared.image(with: id)?.image?.asNSImage().temporaryFileURL()
+                try? ImageStore.shared.image(with: id)?.image?.asTransferableImage().image.temporaryFileURL()
             }
         }
     }
@@ -571,7 +571,7 @@ final class ImageController: ObservableObject {
 }
 
 extension CGImage {
-    func asNSImage() -> NSImage {
-        NSImage(cgImage: self, size: NSSize(width: width, height: height))
+    func asTransferableImage() -> TransferableImage {
+        TransferableImage(image: NSImage(cgImage: self, size: NSSize(width: width, height: height)))
     }
 }


### PR DESCRIPTION
Apple Feedback recommended against extending AppKit to conform to the transferable protocol and suggested using a wrapper. Below is their suggestion, which differs slightly from this PR in order to work well with the codebase.

This addresses issue #290 

If possible, test on both macOS 13 and macOS 14 beta.

```swift
@available(macOS, introduced: 13.0, deprecated: 14.0)
public struct TransferableImage {
    public let image: NSImage
}

extension TransferableImage: Transferable {
    public static var transferRepresentation: some TransferRepresentation {
        if #available(macOS 14.0, *) {
            return NSImage.transferRepresentation
        } else {
            return ProxyRepresentation<TransferableImage, URL>(exporting: { (transferableImage: TransferableImage) in
                return try transferableImage.image.temporaryFileURL()
            })
        }
    }
}

extension NSImage {
    fileprivate static var urlCache = [Int: URL]()
    
    fileprivate func temporaryFileURL() throws -> URL {
        let imageHash = self.getImageHash()
        if let cachedURL = Self.urlCache[imageHash] {
            return cachedURL
        }
        let name = String(imageHash)
        let url = FileManager.default.temporaryDirectory.appendingPathComponent(name, conformingTo: .png)
        let fileWrapper = FileWrapper(regularFileWithContents: self.toPngData())
        try fileWrapper.write(to: url, originalContentsURL: nil)
        Self.urlCache[imageHash] = url
        return url
    }
    
    private static func cleanupTempFiles() {
        for url in self.urlCache {
            try? FileManager.default.removeItem(at: url.value)
        }
    }
}
```
