### PR TITLE
Fix vae scale factor for SDXL models

### DIFF
--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -254,6 +254,7 @@ final class ImageController: ObservableObject {
 
         let genConfig = GenerationConfig(
             pipelineConfig: pipelineConfig,
+            isXL: model.isXL,
             autosaveImages: autosaveImages,
             imageDir: imageDir,
             imageType: imageType,

--- a/Mochi Diffusion/Support/ImageGenerator.swift
+++ b/Mochi Diffusion/Support/ImageGenerator.swift
@@ -13,6 +13,7 @@ import UniformTypeIdentifiers
 
 struct GenerationConfig: Sendable {
     var pipelineConfig: StableDiffusionPipeline.Configuration
+    var isXL: Bool
     var autosaveImages: Bool
     var imageDir: String
     var imageType: String
@@ -186,6 +187,11 @@ class ImageGenerator: ObservableObject {
         generationStopped = false
         var config = inputConfig
         config.pipelineConfig.seed = config.pipelineConfig.seed == 0 ? UInt32.random(in: 0 ..< UInt32.max) : config.pipelineConfig.seed
+
+        if config.isXL {
+            config.pipelineConfig.encoderScaleFactor = 0.13025
+            config.pipelineConfig.decoderScaleFactor = 0.13025
+        }
 
         var sdi = SDImage()
         sdi.prompt = config.pipelineConfig.prompt


### PR DESCRIPTION
Separate configs for SDXL are still in the works, but for now this will correct the "muted" colors you might see in base SDXL models. Similar to https://github.com/huggingface/swift-coreml-diffusers/pull/79