### PR TITLE
fix: text editing hot keys interrupt by gallery hot keys

### DIFF
--- a/Mochi Diffusion/App.swift
+++ b/Mochi Diffusion/App.swift
@@ -59,7 +59,7 @@ struct MochiDiffusionApp: App {
             AppCommands(updater: updaterController.updater)
             FileCommands(store: store)
             SidebarCommands()
-            ImageCommands(controller: controller, generator: generator, store: store)
+            ImageCommands(controller: controller, generator: generator, store: store, focusController: focusCon)
             HelpCommands()
         }
         .defaultSize(width: 1_120, height: 670)

--- a/Mochi Diffusion/Main Menu/ImageCommands.swift
+++ b/Mochi Diffusion/Main Menu/ImageCommands.swift
@@ -13,10 +13,6 @@ struct ImageCommands: Commands {
     @ObservedObject var store: ImageStore
     @ObservedObject var focusController: FocusController
 
-    private var isTextFieldFocused: Bool {
-        $focusController.negativePromptFieldIsFocused.wrappedValue || $focusController.promptFieldIsFocused.wrappedValue || $focusController.seedFieldIsFocused.wrappedValue
-    }
-
     var body: some Commands {
         CommandMenu("Image") {
             Section {
@@ -47,7 +43,7 @@ struct ImageCommands: Commands {
                     )
                 }
                 .keyboardShortcut(.rightArrow, modifiers: .command)
-                .disabled(store.images.isEmpty || isTextFieldFocused)
+                .disabled(store.images.isEmpty || focusController.isTextFieldFocused)
 
                 Button {
                     Task { await ImageController.shared.selectPrevious() }
@@ -58,7 +54,7 @@ struct ImageCommands: Commands {
                     )
                 }
                 .keyboardShortcut(.leftArrow, modifiers: .command)
-                .disabled(store.images.isEmpty || isTextFieldFocused)
+                .disabled(store.images.isEmpty || focusController.isTextFieldFocused)
             }
             Section {
                 Button {
@@ -93,7 +89,7 @@ struct ImageCommands: Commands {
                     )
                 }
                 .keyboardShortcut(.delete, modifiers: .command)
-                .disabled(store.selected() == nil || isTextFieldFocused)
+                .disabled(store.selected() == nil || focusController.isTextFieldFocused)
             }
         }
     }

--- a/Mochi Diffusion/Main Menu/ImageCommands.swift
+++ b/Mochi Diffusion/Main Menu/ImageCommands.swift
@@ -11,6 +11,11 @@ struct ImageCommands: Commands {
     @ObservedObject var controller: ImageController
     @ObservedObject var generator: ImageGenerator
     @ObservedObject var store: ImageStore
+    @ObservedObject var focusController: FocusController
+
+    private var isTextFieldFocused: Bool {
+        $focusController.negativePromptFieldIsFocused.wrappedValue || $focusController.promptFieldIsFocused.wrappedValue || $focusController.seedFieldIsFocused.wrappedValue
+    }
 
     var body: some Commands {
         CommandMenu("Image") {
@@ -42,7 +47,7 @@ struct ImageCommands: Commands {
                     )
                 }
                 .keyboardShortcut(.rightArrow, modifiers: .command)
-                .disabled(store.images.isEmpty)
+                .disabled(store.images.isEmpty || isTextFieldFocused)
 
                 Button {
                     Task { await ImageController.shared.selectPrevious() }
@@ -53,7 +58,7 @@ struct ImageCommands: Commands {
                     )
                 }
                 .keyboardShortcut(.leftArrow, modifiers: .command)
-                .disabled(store.images.isEmpty)
+                .disabled(store.images.isEmpty || isTextFieldFocused)
             }
             Section {
                 Button {
@@ -88,7 +93,7 @@ struct ImageCommands: Commands {
                     )
                 }
                 .keyboardShortcut(.delete, modifiers: .command)
-                .disabled(store.selected() == nil)
+                .disabled(store.selected() == nil || isTextFieldFocused)
             }
         }
     }

--- a/Mochi Diffusion/Main Menu/ImageCommands.swift
+++ b/Mochi Diffusion/Main Menu/ImageCommands.swift
@@ -42,7 +42,7 @@ struct ImageCommands: Commands {
                         comment: "Select next image in Gallery"
                     )
                 }
-                .keyboardShortcut(.rightArrow, modifiers: .command)
+                .keyboardShortcut(.rightArrow, modifiers: [])
                 .disabled(store.images.isEmpty || focusController.isTextFieldFocused)
 
                 Button {
@@ -53,7 +53,7 @@ struct ImageCommands: Commands {
                         comment: "Select previous image in Gallery"
                     )
                 }
-                .keyboardShortcut(.leftArrow, modifiers: .command)
+                .keyboardShortcut(.leftArrow, modifiers: [])
                 .disabled(store.images.isEmpty || focusController.isTextFieldFocused)
             }
             Section {

--- a/Mochi Diffusion/Support/FocusController.swift
+++ b/Mochi Diffusion/Support/FocusController.swift
@@ -19,6 +19,10 @@ final class FocusController: ObservableObject {
 
     @Published var seedFieldIsFocused = false
 
+    var isTextFieldFocused: Bool {
+        negativePromptFieldIsFocused || promptFieldIsFocused || seedFieldIsFocused
+    }
+
     /// Remove focus from all fields.
     func removeAllFocus() {
         promptFieldIsFocused = false


### PR DESCRIPTION
In this PR i made changes to disables gallery view image selection when user is editing textfields.
Fixes: #312 