### PR TITLE
Rearrange image-to-image sidebar section

### DIFF
--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -134,7 +134,7 @@ final class ImageController: ObservableObject {
     @AppStorage("ImageType") var imageType = UTType.png.preferredFilenameExtension!
     @AppStorage("Prompt") var prompt = ""
     @AppStorage("NegativePrompt") var negativePrompt = ""
-    @AppStorage("ImageStrength") var strength = 0.72
+    @AppStorage("ImageStrength") var strength = 0.75
     @AppStorage("Steps") var steps = 12.0
     @AppStorage("Scale") var guidanceScale = 11.0
     @AppStorage("ImageWidth") var width = 512

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -40,46 +40,46 @@ struct StartingImageView: View {
     @State private var isInfoPopoverShown = false
 
     var body: some View {
-        HStack(alignment: .top) {
-            VStack(alignment: .leading) {
-                Text(
-                    "Starting Image",
-                    comment: "Label for setting the starting image (commonly known as image2image)"
-                )
-                .sidebarLabelFormat()
-
-                ImageView(image: $controller.startingImage)
-                    .frame(height: 90)
+        VStack(alignment: .leading) {
+            Text(
+                "Image-to-image",
+                comment: "Label for setting the starting image (commonly known as image2image)"
+            )
+            .sidebarLabelFormat()
+            
+            HStack(alignment: .top) {
+                VStack(alignment: .leading) {
+                    ImageView(image: $controller.startingImage)
+                        .frame(height: 90)
+                }
+                
+                Spacer()
+                
+                VStack(alignment: .trailing) {
+                    HStack {
+                        Button {
+                            Task { await ImageController.shared.selectStartingImage() }
+                        } label: {
+                            Image(systemName: "photo")
+                        }
+                        
+                        Button {
+                            Task { await ImageController.shared.unsetStartingImage() }
+                        } label: {
+                            Image(systemName: "xmark")
+                        }
+                    }
+                }
             }
-
-            Spacer()
-
-            VStack(alignment: .trailing) {
+            HStack {
                 Text(
                     "Strength",
                     comment: "Label for starting image strength slider control"
                 )
                 .sidebarLabelFormat()
-
-                Slider(value: $controller.strength, in: 0.37...1, step: 0.07)
-                    .controlSize(.mini)
-
-                HStack {
-                    Button {
-                        Task { await ImageController.shared.selectStartingImage() }
-                    } label: {
-                        Image(systemName: "photo")
-                    }
-
-                    Button {
-                        Task { await ImageController.shared.unsetStartingImage() }
-                    } label: {
-                        Image(systemName: "xmark")
-                    }
-                }
-
+                
                 Spacer()
-
+                
                 Button {
                     self.isInfoPopoverShown.toggle()
                 } label: {
@@ -89,17 +89,22 @@ struct StartingImageView: View {
                 .buttonStyle(PlainButtonStyle())
                 .popover(isPresented: self.$isInfoPopoverShown, arrowEdge: .top) {
                     Text(
-                    """
-                    Strength controls how closely the generated image resembles the starting image.
-                    Use lower values to generate images that look similar to the starting image.
-                    Use higher values to allow more creative freedom.
-
-                    The size of the starting image must match the output image size of the current model.
-                    """
+                """
+                Strength controls how closely the generated image resembles the starting image.
+                Use lower values to generate images that look similar to the starting image.
+                Use higher values to allow more creative freedom.
+                
+                The size of the starting image must match the output image size of the current model.
+                """
                     )
                     .padding()
                 }
             }
+            CompactSlider(value: $controller.strength, in: 0.0...1.0, step: 0.05) {
+                Text(verbatim: "\(controller.strength.formatted(.number.precision(.fractionLength(2))))")
+                Spacer()
+            }
+             .compactSliderStyle(.mochi)
         }
     }
 }

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -40,55 +40,55 @@ struct StartingImageView: View {
     @State private var isInfoPopoverShown = false
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Text(
-                "Image-to-image",
-                comment: "Label for setting the starting image (commonly known as image2image)"
-            )
-            .sidebarLabelFormat()
+        Text(
+            "Starting Image",
+            comment: "Label for setting the starting image (commonly known as image2image)"
+        )
+        .sidebarLabelFormat()
 
-            HStack(alignment: .top) {
-                VStack(alignment: .leading) {
-                    ImageView(image: $controller.startingImage)
-                        .frame(height: 90)
-                }
+        HStack(alignment: .top) {
+            VStack(alignment: .leading) {
+                ImageView(image: $controller.startingImage)
+                    .frame(height: 90)
+            }
 
-                Spacer()
+            Spacer()
 
-                VStack(alignment: .trailing) {
-                    HStack {
-                        Button {
-                            Task { await ImageController.shared.selectStartingImage() }
-                        } label: {
-                            Image(systemName: "photo")
-                        }
+            VStack(alignment: .trailing) {
+                HStack {
+                    Button {
+                        Task { await ImageController.shared.selectStartingImage() }
+                    } label: {
+                        Image(systemName: "photo")
+                    }
 
-                        Button {
-                            Task { await ImageController.shared.unsetStartingImage() }
-                        } label: {
-                            Image(systemName: "xmark")
-                        }
+                    Button {
+                        Task { await ImageController.shared.unsetStartingImage() }
+                    } label: {
+                        Image(systemName: "xmark")
                     }
                 }
             }
-            HStack {
+        }
+
+        HStack {
+            Text(
+                "Strength",
+                comment: "Label for starting image strength slider control"
+            )
+            .sidebarLabelFormat()
+
+            Spacer()
+
+            Button {
+                self.isInfoPopoverShown.toggle()
+            } label: {
+                Image(systemName: "info.circle")
+                    .foregroundColor(Color.secondary)
+            }
+            .buttonStyle(PlainButtonStyle())
+            .popover(isPresented: self.$isInfoPopoverShown, arrowEdge: .top) {
                 Text(
-                    "Strength",
-                    comment: "Label for starting image strength slider control"
-                )
-                .sidebarLabelFormat()
-
-                Spacer()
-
-                Button {
-                    self.isInfoPopoverShown.toggle()
-                } label: {
-                    Image(systemName: "info.circle")
-                        .foregroundColor(Color.secondary)
-                }
-                .buttonStyle(PlainButtonStyle())
-                .popover(isPresented: self.$isInfoPopoverShown, arrowEdge: .top) {
-                    Text(
                 """
                 Strength controls how closely the generated image resembles the starting image.
                 Use lower values to generate images that look similar to the starting image.
@@ -96,16 +96,16 @@ struct StartingImageView: View {
 
                 The size of the starting image must match the output image size of the current model.
                 """
-                    )
-                    .padding()
-                }
+                )
+                .padding()
             }
-            CompactSlider(value: $controller.strength, in: 0.0...1.0, step: 0.05) {
-                Text(verbatim: "\(controller.strength.formatted(.number.precision(.fractionLength(2))))")
-                Spacer()
-            }
-            .compactSliderStyle(.mochi)
         }
+
+        CompactSlider(value: $controller.strength, in: 0.0...1.0, step: 0.05) {
+            Text(verbatim: "\(controller.strength.formatted(.number.precision(.fractionLength(2))))")
+            Spacer()
+        }
+        .compactSliderStyle(.mochi)
     }
 }
 

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -46,15 +46,15 @@ struct StartingImageView: View {
                 comment: "Label for setting the starting image (commonly known as image2image)"
             )
             .sidebarLabelFormat()
-            
+
             HStack(alignment: .top) {
                 VStack(alignment: .leading) {
                     ImageView(image: $controller.startingImage)
                         .frame(height: 90)
                 }
-                
+
                 Spacer()
-                
+
                 VStack(alignment: .trailing) {
                     HStack {
                         Button {
@@ -62,7 +62,7 @@ struct StartingImageView: View {
                         } label: {
                             Image(systemName: "photo")
                         }
-                        
+
                         Button {
                             Task { await ImageController.shared.unsetStartingImage() }
                         } label: {
@@ -77,9 +77,9 @@ struct StartingImageView: View {
                     comment: "Label for starting image strength slider control"
                 )
                 .sidebarLabelFormat()
-                
+
                 Spacer()
-                
+
                 Button {
                     self.isInfoPopoverShown.toggle()
                 } label: {
@@ -93,7 +93,7 @@ struct StartingImageView: View {
                 Strength controls how closely the generated image resembles the starting image.
                 Use lower values to generate images that look similar to the starting image.
                 Use higher values to allow more creative freedom.
-                
+
                 The size of the starting image must match the output image size of the current model.
                 """
                     )
@@ -104,7 +104,7 @@ struct StartingImageView: View {
                 Text(verbatim: "\(controller.strength.formatted(.number.precision(.fractionLength(2))))")
                 Spacer()
             }
-             .compactSliderStyle(.mochi)
+            .compactSliderStyle(.mochi)
         }
     }
 }


### PR DESCRIPTION
- lower strength slider minimum value to 0
- move stength slider below starting image selection/preview
- align info (i) button with "Strength" heading

before:
<img width="227" alt="Screenshot 2023-11-07 at 3 19 50 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/8458547/ddc5b666-f36e-473d-80f9-24f71165b10b">

after:
<img width="231" alt="Screenshot 2023-11-07 at 3 19 05 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/8458547/944c2b5f-7e37-49e7-bb67-7df911b28dcb">

The purpose of this change is to allow very low strength img2img generations. The current min value is 0.37 in part because it is too finicky and difficult to pick from the full range of 0.0 to 1.0 with such a small slider. Moving the slider below the image picker allows it to be the full sidebar width.