### PR TITLE
Allow the Starting Image to be set by drag and drop

### DIFF
--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		58FF218829FAE96200A70C7C /* ControlNetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FF218729FAE96200A70C7C /* ControlNetView.swift */; };
 		948853A52A543CB200B4AD86 /* GalleryPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 948853A42A543CB200B4AD86 /* GalleryPreviewView.swift */; };
 		9B7392C3298DEAC2006F03D5 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7392C2298DEAC2006F03D5 /* Tokenizer.swift */; };
+		C1220FC02AFB122F007E5055 /* ImageWellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1220FBF2AFB122F007E5055 /* ImageWellView.swift */; };
 		D7B03F2029D42F9900DF89DD /* SDModelAttentionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B03F1F29D42F9900DF89DD /* SDModelAttentionType.swift */; };
 /* End PBXBuildFile section */
 
@@ -121,6 +122,7 @@
 		58FF218729FAE96200A70C7C /* ControlNetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlNetView.swift; sourceTree = "<group>"; };
 		948853A42A543CB200B4AD86 /* GalleryPreviewView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GalleryPreviewView.swift; sourceTree = "<group>"; };
 		9B7392C2298DEAC2006F03D5 /* Tokenizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
+		C1220FBF2AFB122F007E5055 /* ImageWellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageWellView.swift; sourceTree = "<group>"; };
 		D7B03F1F29D42F9900DF89DD /* SDModelAttentionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDModelAttentionType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -178,6 +180,7 @@
 				035EDFFF295A224900080D18 /* ModelView.swift */,
 				58FF218729FAE96200A70C7C /* ControlNetView.swift */,
 				035EDFFB295A21D600080D18 /* SizeView.swift */,
+				C1220FBF2AFB122F007E5055 /* ImageWellView.swift */,
 			);
 			path = SidebarControls;
 			sourceTree = "<group>";
@@ -438,6 +441,7 @@
 				03D43B7A29660A2600604911 /* GalleryItemView.swift in Sources */,
 				035EDFF8295A216500080D18 /* StepsView.swift in Sources */,
 				03061E6229AB9C06009AA2A2 /* FocusController.swift in Sources */,
+				C1220FC02AFB122F007E5055 /* ImageWellView.swift in Sources */,
 				03FD231B295F7A81006EEEE2 /* Upscaler.swift in Sources */,
 				0380934329AD504600EDBC8E /* StartingImageView.swift in Sources */,
 				03173C152999F5C700B03456 /* ImageController.swift in Sources */,

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -366,6 +366,10 @@ final class ImageController: ObservableObject {
         await removeImage(sdi)
     }
 
+    func setStartingImage(image: CGImage) {
+        startingImage = image
+    }
+
     func selectStartingImage() async {
         startingImage = await selectImage()
     }

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -16,57 +16,15 @@ struct ControlNetView: View {
             .sidebarLabelFormat()
 
         HStack(alignment: .top) {
-            if let image = controller.currentControlNets.first?.image {
-                Image(image, scale: 1, label: Text(verbatim: ""))
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .padding(3)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 2)
-                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                    )
-                    .frame(height: 90)
-                    .accessibilityAddTraits(.isButton)
-            } else {
-                Button {
-                    Task { await ImageController.shared.selectControlNetImage(at: 0) }
-                } label: {
-                    Image(systemName: "photo")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .foregroundColor(Color(nsColor: .separatorColor))
-                        .padding(30)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 2)
-                                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                        )
-                        .background(.background.opacity(0.01))
-                        .frame(height: 90)
-                        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
-                            _ = providers.first?.loadDataRepresentation(for: .fileURL) { data, _ in
-                                guard let data, let urlString = String(data: data, encoding: .utf8), let url = URL(string: urlString) else {
-                                    return
-                                }
-
-                                guard let cgImageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
-                                    return
-                                }
-
-                                let imageIndex = CGImageSourceGetPrimaryImageIndex(cgImageSource)
-
-                                guard let cgImage = CGImageSourceCreateImageAtIndex(cgImageSource, imageIndex, nil) else {
-                                    return
-                                }
-
-                                Task { await ImageController.shared.setControlNet(image: cgImage) }
-                            }
-
-                            return true
-                        }
+            ImageWellView(image: controller.currentControlNets.first?.image) { image in
+                if let image {
+                    await ImageController.shared.setControlNet(image: image)
+                } else {
+                    await ImageController.shared.unsetControlNet()
                 }
-                .buttonStyle(.plain)
-                .disabled(controller.controlNet.isEmpty)
             }
+            .disabled(controller.controlNet.isEmpty)
+            .frame(height: 90)
 
             Spacer()
 

--- a/Mochi Diffusion/Views/SidebarControls/ImageWellView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ImageWellView.swift
@@ -12,19 +12,19 @@ struct ImageWellView: View {
     let setImage: (CGImage?) async -> Void
 
     var body: some View {
-        if let image = image {
-            Image(image, scale: 1, label: Text(verbatim: ""))
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .padding(3)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 2)
-                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                )
-        } else {
-            Button {
-                Task { await setImage(ImageController.shared.selectImage()) }
-            } label: {
+        Button {
+            Task { await setImage(ImageController.shared.selectImage()) }
+        } label: {
+            if let image = image {
+                Image(image, scale: 1, label: Text(verbatim: ""))
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .padding(3)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 2)
+                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                    )
+            } else {
                 Image(systemName: "photo")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
@@ -35,29 +35,29 @@ struct ImageWellView: View {
                             .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
                     )
                     .background(.background.opacity(0.01))
-                    .onDrop(of: [.fileURL], isTargeted: nil) { providers in
-                        _ = providers.first?.loadDataRepresentation(for: .fileURL) { data, _ in
-                            guard let data, let urlString = String(data: data, encoding: .utf8), let url = URL(string: urlString) else {
-                                return
-                            }
-
-                            guard let cgImageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
-                                return
-                            }
-
-                            let imageIndex = CGImageSourceGetPrimaryImageIndex(cgImageSource)
-
-                            guard let cgImage = CGImageSourceCreateImageAtIndex(cgImageSource, imageIndex, nil) else {
-                                return
-                            }
-
-                            Task { await self.setImage(cgImage) }
-                        }
-
-                        return true
-                    }
             }
-            .buttonStyle(.plain)
+        }
+        .buttonStyle(.plain)
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            _ = providers.first?.loadDataRepresentation(for: .fileURL) { data, _ in
+                guard let data, let urlString = String(data: data, encoding: .utf8), let url = URL(string: urlString) else {
+                    return
+                }
+
+                guard let cgImageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+                    return
+                }
+
+                let imageIndex = CGImageSourceGetPrimaryImageIndex(cgImageSource)
+
+                guard let cgImage = CGImageSourceCreateImageAtIndex(cgImageSource, imageIndex, nil) else {
+                    return
+                }
+
+                Task { await self.setImage(cgImage) }
+            }
+
+            return true
         }
     }
 }

--- a/Mochi Diffusion/Views/SidebarControls/ImageWellView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ImageWellView.swift
@@ -1,0 +1,63 @@
+//
+//  ImageWellView.swift
+//  Mochi Diffusion
+//
+//  Created by Graham Bing on 2023-11-07.
+//
+
+import SwiftUI
+
+struct ImageWellView: View {
+    var image: CGImage?
+    let setImage: (CGImage?) async -> Void
+
+    var body: some View {
+        if let image = image {
+            Image(image, scale: 1, label: Text(verbatim: ""))
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .padding(3)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 2)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                )
+        } else {
+            Button {
+                Task { await setImage(ImageController.shared.selectImage()) }
+            } label: {
+                Image(systemName: "photo")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .foregroundColor(Color(nsColor: .separatorColor))
+                    .padding(30)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 2)
+                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                    )
+                    .background(.background.opacity(0.01))
+                    .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+                        _ = providers.first?.loadDataRepresentation(for: .fileURL) { data, _ in
+                            guard let data, let urlString = String(data: data, encoding: .utf8), let url = URL(string: urlString) else {
+                                return
+                            }
+
+                            guard let cgImageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+                                return
+                            }
+
+                            let imageIndex = CGImageSourceGetPrimaryImageIndex(cgImageSource)
+
+                            guard let cgImage = CGImageSourceCreateImageAtIndex(cgImageSource, imageIndex, nil) else {
+                                return
+                            }
+
+                            Task { await self.setImage(cgImage) }
+                        }
+
+                        return true
+                    }
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -20,16 +20,14 @@ struct StartingImageView: View {
         .sidebarLabelFormat()
 
         HStack(alignment: .top) {
-            VStack(alignment: .leading) {
-                ImageWellView(image: controller.startingImage) { image in
-                    if let image {
-                        ImageController.shared.setStartingImage(image: image)
-                    } else {
-                        await ImageController.shared.unsetStartingImage()
-                    }
+            ImageWellView(image: controller.startingImage) { image in
+                if let image {
+                    ImageController.shared.setStartingImage(image: image)
+                } else {
+                    await ImageController.shared.unsetStartingImage()
                 }
-                .frame(height: 90)
             }
+            .frame(height: 90)
 
             Spacer()
 

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -8,61 +8,6 @@
 import CompactSlider
 import SwiftUI
 
-struct ImageWellView: View {
-    var image: CGImage?
-    let setImage: (CGImage?) async -> Void
-
-    var body: some View {
-        if let image = image {
-            Image(image, scale: 1, label: Text(verbatim: ""))
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .padding(3)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 2)
-                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                )
-        } else {
-            Button {
-                Task { await setImage(ImageController.shared.selectImage()) }
-            } label: {
-                Image(systemName: "photo")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .foregroundColor(Color(nsColor: .separatorColor))
-                    .padding(30)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 2)
-                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                    )
-                    .background(.background.opacity(0.01))
-                    .onDrop(of: [.fileURL], isTargeted: nil) { providers in
-                        _ = providers.first?.loadDataRepresentation(for: .fileURL) { data, _ in
-                            guard let data, let urlString = String(data: data, encoding: .utf8), let url = URL(string: urlString) else {
-                                return
-                            }
-
-                            guard let cgImageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
-                                return
-                            }
-
-                            let imageIndex = CGImageSourceGetPrimaryImageIndex(cgImageSource)
-
-                            guard let cgImage = CGImageSourceCreateImageAtIndex(cgImageSource, imageIndex, nil) else {
-                                return
-                            }
-
-                            Task { await self.setImage(cgImage) }
-                        }
-
-                        return true
-                    }
-            }
-            .buttonStyle(.plain)
-        }
-    }
-}
-
 struct StartingImageView: View {
     @EnvironmentObject private var controller: ImageController
     @State private var isInfoPopoverShown = false


### PR DESCRIPTION
fixes: #267 

This PR updates the img2img image well to support drag and drop, like the ControlNet image well already does. It doesn't remove the buttons or change the size of the image well, or any of the layout changes that were discussed in the issue page, it just allows user to drag and drop an image to load it.

Additionally
- I refactored ControlNetView to use the new ImageWellView, instead of duplicating its functionality.
- dragging an image to a well which already has an image now replaces it with the new image, previously the ControlNet image well was disabled once it was loaded with an image