### PR TITLE
Refactor ImageController and ImageGenerator to facilitate queued generations

### DIFF
--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -95,7 +95,9 @@ final class ImageController: ObservableObject {
             controlNet = model.controlNet
             currentControlNets = []
 
-            loadPipeline()
+            if case .ready = ImageGenerator.shared.state {
+                loadPipeline()
+            }
         }
     }
 
@@ -418,7 +420,10 @@ final class ImageController: ObservableObject {
         } else {
             self.currentControlNets[0].name = name
         }
-        loadPipeline()
+
+        if case .ready = ImageGenerator.shared.state {
+            loadPipeline()
+        }
     }
 
     func setControlNet(image: CGImage) async {
@@ -427,12 +432,18 @@ final class ImageController: ObservableObject {
         } else {
             self.currentControlNets[0].image = image
         }
-        loadPipeline()
+
+        if case .ready = ImageGenerator.shared.state {
+            loadPipeline()
+        }
     }
 
     func unsetControlNet() async {
         self.currentControlNets = []
-        loadPipeline()
+
+        if case .ready = ImageGenerator.shared.state {
+            loadPipeline()
+        }
     }
 
     func selectControlNetImage(at index: Int) async {
@@ -445,7 +456,10 @@ final class ImageController: ObservableObject {
                 currentControlNets[index].image = image
             }
         }
-        loadPipeline()
+
+        if case .ready = ImageGenerator.shared.state {
+            loadPipeline()
+        }
     }
 
     func unsetControlNetImage(at index: Int) async {

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -292,11 +292,11 @@ final class ImageController: ObservableObject {
                     )
                     try await ImageGenerator.shared.generate(genConfig)
                 } catch ImageGenerator.GeneratorError.requestedModelNotFound {
-                    // TODO:
+                    await self.logger.error("Couldn't load \(genConfig.model.name) because it doesn't exist.")
+                    await ImageGenerator.shared.updateState(.ready("Couldn't load \(genConfig.model.name) because it doesn't exist."))
                 } catch ImageGenerator.GeneratorError.pipelineNotAvailable {
                     await self.logger.error("Pipeline is not available.")
-                    await self.logger.error("There was a problem loading pipelines")
-                    // TODO: is it XL?
+                    await ImageGenerator.shared.updateState(.ready("There was a problem loading pipeline."))
                 } catch PipelineError.startingImageProvidedWithoutEncoder {
                     await self.logger.error("The selected model does not support setting a starting image.")
                     await ImageGenerator.shared.updateState(.ready("The selected model does not support setting a starting image."))

--- a/Mochi Diffusion/Support/ImageGenerator.swift
+++ b/Mochi Diffusion/Support/ImageGenerator.swift
@@ -11,17 +11,19 @@ import OSLog
 @preconcurrency import StableDiffusion
 import UniformTypeIdentifiers
 
-struct GenerationConfig: Sendable {
+struct GenerationConfig: Sendable, Identifiable {
+    let id = UUID()
     var pipelineConfig: StableDiffusionPipeline.Configuration
     var isXL: Bool
     var autosaveImages: Bool
     var imageDir: String
     var imageType: String
     var numberOfImages: Int
-    var model: String
+    let model: SDModel
     var mlComputeUnit: MLComputeUnits
     var scheduler: Scheduler
     var upscaleGeneratedImages: Bool
+    var controlNets: [String]
 }
 
 class ImageGenerator: ObservableObject {
@@ -213,7 +215,7 @@ class ImageGenerator: ObservableObject {
         var sdi = SDImage()
         sdi.prompt = config.pipelineConfig.prompt
         sdi.negativePrompt = config.pipelineConfig.negativePrompt
-        sdi.model = config.model
+        sdi.model = config.model.name
         sdi.scheduler = config.scheduler
         sdi.mlComputeUnit = config.mlComputeUnit
         sdi.steps = config.pipelineConfig.stepCount

--- a/Mochi Diffusion/Support/ImageGenerator.swift
+++ b/Mochi Diffusion/Support/ImageGenerator.swift
@@ -40,7 +40,6 @@ class ImageGenerator: ObservableObject {
     }
 
     enum State: Sendable {
-        case idle
         case ready(String?)
         case error(String)
         case loading
@@ -49,7 +48,7 @@ class ImageGenerator: ObservableObject {
 
     @MainActor
     @Published
-    private(set) var state = State.idle
+    private(set) var state = State.ready(nil)
 
     struct QueueProgress: Sendable {
         var index = 0


### PR DESCRIPTION
begins to address #251 

This PR updates the model and controller classes to make it possible to queue up generations to be performed automatically in sequence. It does not change the UI to actually enable users to do so, that will need to happen in a future PR, but curious developers can comment out the conditional `if case .running = generator.state {` in PromptView.swift to enable the Generate button during `.loading` and `.running`, and try it out.

---

Broadly, this change is about loading the pipeline right before running generation, so that different pipelines can be saved and queued up with corresponding generation jobs.

## Image Generator
- stores a hash of the current pipeline and checks it before loading pipeline
  - it's wasteful to load pipeline even if it is unchanged between queued generations
- `GenerationConfig`
  - replace `String` model name in `GenerationConfig` with the whole `SDModel` model
    - `loadPipeline` requires the model, and this is the easiest way to store it in `generationQueue`
  - `controlNets`
    - likewise, passed through `GenerationConfig` to `loadPipeline`
  - alternatively, `generationQueue` could store tuples or dicts or objects with the original `GenerationConfig` and the required pipeline parameter objects

- remove `.idle` state
  - idle is the initial state that signifies Mochi has just started and isn't ready to generate because pipeline wasn't loaded yet
  - now that pipeline is loaded as part of generation, there is no meaningful distinction between `.idle` and `.ready`

## ImageController
- new `currentGeneration` property
  - exposes information about the current running generation, for future use in the UI, or for logging messages
- new `generationQueue` property
  - this is it. this is the queue.
- `generate()`
  - instead of putting together a `GenerationConfig` and calling `ImageGenerator.generate()` on it, `generate` now puts together a `GenerationConfig`, puts it onto a queue, and then calls `runGenerationJobs()` to go through that queue
- `runGenerationJobs()`
  - iterates through `generationQueue`, calling `ImageGenerator.loadPipeline()` and `ImageGenerator.generate()` for each job
- `didSet(currentModel)`, `selectControlNetImage`, `unsetControlNet`, `setControlNet`
  - all the methods which change pipeline parameters, and which used to call `loadPipeline()` still do, but now they only do if no jobs are running, i.e. if the queue is empty
  - in theory this allows us to to preload the pipeline before the first job in a queue is started, for a tiny efficiency gain
  - in practice, i find that it makes almost no difference
    - `loadPipeline()` doesn't call `StableDiffusionPipeline.loadResources()`, those resources are loaded lazily during generation, and they're the part of loading that takes time
  - it might make more sense to just remove these altogether, and move all the pipeline loading to the queue. 
    - give up what appears to me to be an infinitesimal edge case efficiency improvement for less clever code and less complicated logic