### PR TITLE
Automatically resize input images to match model

### DIFF
--- a/Mochi Diffusion/Model/SDModel.swift
+++ b/Mochi Diffusion/Model/SDModel.swift
@@ -11,12 +11,13 @@ import os.log
 
 private let logger = Logger()
 
-struct SDModel: Identifiable, Hashable {
+struct SDModel: Identifiable {
     let url: URL
     let name: String
     let attention: SDModelAttentionType
     let controlNet: [String]
     let isXL: Bool
+    let inputSize: CGSize?
 
     var id: URL { url }
 
@@ -32,6 +33,13 @@ struct SDModel: Identifiable, Hashable {
         self.attention = attention
         self.controlNet = controlNet
         self.isXL = isXL
+        self.inputSize = identifyInputSize(url)
+    }
+}
+
+extension SDModel: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }
 
@@ -96,5 +104,24 @@ private func unetMetadataURL(from url: URL) -> URL? {
 
     return potentialMetadataURLs.first {
         FileManager.default.fileExists(atPath: $0.path(percentEncoded: false))
+    }
+}
+
+private func identifyInputSize(_ url: URL) -> CGSize? {
+    let encoderMetadataURL = url.appending(path: "VAEEncoder.mlmodelc").appending(path: "metadata.json")
+    if let jsonData = try? Data(contentsOf: encoderMetadataURL),
+        let jsonArray = try? JSONSerialization.jsonObject(with: jsonData) as? [[String: Any]],
+        let jsonItem = jsonArray.first,
+        let inputSchema = jsonItem["inputSchema"] as? [[String: Any]],
+        let controlnetCond = inputSchema.first,
+        let shapeString = controlnetCond["shape"] as? String {
+        let shapeIntArray = shapeString.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+            .components(separatedBy: ", ")
+            .compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+        let width = shapeIntArray[3]
+        let height = shapeIntArray[2]
+        return CGSize(width: width, height: height)
+    } else {
+        return nil
     }
 }

--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -51,6 +51,45 @@ extension NSImage {
     }
 }
 
+extension CGImage {
+    func scaledAndCroppedTo(size: CGSize) -> CGImage? {
+        let sizeRatio = size.width / size.height
+        let imageSizeRatio = Double(self.width) / Double(self.height)
+        let scaleFactor = sizeRatio > imageSizeRatio ? size.width / Double(self.width) : size.height / Double(self.height)
+        let scaledWidth = CGFloat(self.width) * scaleFactor
+        let scaledHeight = CGFloat(self.height) * scaleFactor
+
+        // Calculate the origin point of the crop
+        let cropX = (scaledWidth - size.width) / 2.0
+        let cropY = (scaledHeight - size.height) / 2.0
+
+        guard let context = CGContext(
+            data: nil,
+            width: Int(size.width),
+            height: Int(size.height),
+            bitsPerComponent: self.bitsPerComponent,
+            bytesPerRow: 0,
+            space: self.colorSpace ?? CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+
+        // Adjust the context to handle the scaled image
+        context.translateBy(x: -cropX, y: -cropY)
+        context.scaleBy(x: scaleFactor, y: scaleFactor)
+
+        // Draw the image into the context
+        context.interpolationQuality = .high
+        context.draw(self, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        // Extract the cropped and resized image from the context
+        let scaledCroppedImage = context.makeImage()
+
+        return scaledCroppedImage
+    }
+}
+
 @available(macOS, introduced: 13.0, deprecated: 14.0)
 public struct TransferableImage {
     public let image: NSImage

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -258,7 +258,11 @@ final class ImageController: ObservableObject {
         pipelineConfig.guidanceScale = Float(guidanceScale)
         pipelineConfig.disableSafety = !safetyChecker
         pipelineConfig.schedulerType = convertScheduler(scheduler)
-        pipelineConfig.controlNetInputs = currentControlNets.filter { $0.name != nil }.compactMap(\.image)
+        for controlNet in currentControlNets {
+            if let name = controlNet.name, let size = currentModel?.inputSize, let image = controlNet.image?.scaledAndCroppedTo(size: size) {
+                pipelineConfig.controlNetInputs.append(image)
+            }
+        }
         pipelineConfig.useDenoisedIntermediates = showGenerationPreview
 
         let genConfig = GenerationConfig(

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -259,7 +259,7 @@ final class ImageController: ObservableObject {
         pipelineConfig.disableSafety = !safetyChecker
         pipelineConfig.schedulerType = convertScheduler(scheduler)
         for controlNet in currentControlNets {
-            if let name = controlNet.name, let size = currentModel?.inputSize, let image = controlNet.image?.scaledAndCroppedTo(size: size) {
+            if let _ = controlNet.name, let size = currentModel?.inputSize, let image = controlNet.image?.scaledAndCroppedTo(size: size) {
                 pipelineConfig.controlNetInputs.append(image)
             }
         }

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -259,7 +259,7 @@ final class ImageController: ObservableObject {
         pipelineConfig.disableSafety = !safetyChecker
         pipelineConfig.schedulerType = convertScheduler(scheduler)
         for controlNet in currentControlNets {
-            if let _ = controlNet.name, let size = currentModel?.inputSize, let image = controlNet.image?.scaledAndCroppedTo(size: size) {
+            if controlNet.name != nil, let size = currentModel?.inputSize, let image = controlNet.image?.scaledAndCroppedTo(size: size) {
                 pipelineConfig.controlNetInputs.append(image)
             }
         }

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -249,7 +249,9 @@ final class ImageController: ObservableObject {
 
         var pipelineConfig = StableDiffusionPipeline.Configuration(prompt: prompt)
         pipelineConfig.negativePrompt = negativePrompt
-        pipelineConfig.startingImage = startingImage
+        if let size = currentModel?.inputSize {
+            pipelineConfig.startingImage = startingImage?.scaledAndCroppedTo(size: size)
+        }
         pipelineConfig.strength = Float(strength)
         pipelineConfig.stepCount = Int(steps)
         pipelineConfig.seed = seed

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -16,20 +16,14 @@ struct ControlNetView: View {
             .sidebarLabelFormat()
 
         HStack(alignment: .top) {
-            let aspectRatio: Double = {
-                if let size = controller.currentModel?.inputSize {
-                    return size.width / size.height
-                } else {
-                    return 1.0
-                }
-            }()
-            ImageWellView(image: controller.currentControlNets.first?.image, aspectRatio: aspectRatio) { image in
+            ImageWellView(image: controller.currentControlNets.first?.image, size: controller.currentModel?.inputSize) { image in
                 if let image {
                     await ImageController.shared.setControlNet(image: image)
                 } else {
                     await ImageController.shared.unsetControlNet()
                 }
             }
+            .frame(width: 90, height: 90)
             .disabled(controller.controlNet.isEmpty)
 
             Spacer()

--- a/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ControlNetView.swift
@@ -16,7 +16,14 @@ struct ControlNetView: View {
             .sidebarLabelFormat()
 
         HStack(alignment: .top) {
-            ImageWellView(image: controller.currentControlNets.first?.image) { image in
+            let aspectRatio: Double = {
+                if let size = controller.currentModel?.inputSize {
+                    return size.width / size.height
+                } else {
+                    return 1.0
+                }
+            }()
+            ImageWellView(image: controller.currentControlNets.first?.image, aspectRatio: aspectRatio) { image in
                 if let image {
                     await ImageController.shared.setControlNet(image: image)
                 } else {
@@ -24,7 +31,6 @@ struct ControlNetView: View {
                 }
             }
             .disabled(controller.controlNet.isEmpty)
-            .frame(height: 90)
 
             Spacer()
 

--- a/Mochi Diffusion/Views/SidebarControls/ImageWellView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ImageWellView.swift
@@ -9,34 +9,50 @@ import SwiftUI
 
 struct ImageWellView: View {
     var image: CGImage?
-    var aspectRatio: Double
+    let widthModifier: Double
+    let heightModifier: Double
     let setImage: (CGImage?) async -> Void
+
+    init(image: CGImage? = nil, size: CGSize?, setImage: @escaping (CGImage?) async -> Void) {
+        self.image = image
+        if let width = size?.width, let height = size?.height {
+            let aspectRatio = width / height
+            self.widthModifier = aspectRatio > 1.0 ? 1 / aspectRatio : 1.0
+            self.heightModifier = aspectRatio < 1.0 ? aspectRatio : 1.0
+        } else {
+            self.widthModifier = 1.0
+            self.heightModifier = 1.0
+        }
+        self.setImage = setImage
+    }
 
     var body: some View {
         Button {
             Task { await setImage(ImageController.shared.selectImage()) }
         } label: {
-            ZStack {
-                RoundedRectangle(cornerRadius: 2)
-                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                    .background(.background.opacity(0.01))
-
-                if let image = image {
-                    Image(image, scale: 1, label: Text(verbatim: ""))
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                } else {
-                    Image(systemName: "photo")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 30)
-                        .foregroundColor(Color(nsColor: .separatorColor))
+            GeometryReader { proxy in
+                ZStack {
+                    if let image = image {
+                        Image(image, scale: 1, label: Text(verbatim: ""))
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: proxy.size.width * widthModifier, height: proxy.size.height * heightModifier)
+                            .clipped()
+                    } else {
+                        RoundedRectangle(cornerRadius: 2)
+                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                            .background(.background.opacity(0.01))
+                            .frame(width: proxy.size.width * widthModifier, height: proxy.size.height * heightModifier)
+                        Image(systemName: "photo")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 30)
+                            .foregroundColor(Color(nsColor: .separatorColor))
+                    }
                 }
+                .frame(width: proxy.size.width, height: proxy.size.height)
             }
-            .frame(width: 80 * aspectRatio, height: 80)
-            .clipped()
         }
-        .aspectRatio(contentMode: .fill)
         .buttonStyle(.plain)
         .onDrop(of: [.fileURL], isTargeted: nil) { providers in
             _ = providers.first?.loadDataRepresentation(for: .fileURL) { data, _ in

--- a/Mochi Diffusion/Views/SidebarControls/ImageWellView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ImageWellView.swift
@@ -17,8 +17,8 @@ struct ImageWellView: View {
         self.image = image
         if let width = size?.width, let height = size?.height {
             let aspectRatio = width / height
-            self.widthModifier = aspectRatio > 1.0 ? 1 / aspectRatio : 1.0
-            self.heightModifier = aspectRatio < 1.0 ? aspectRatio : 1.0
+            self.widthModifier = aspectRatio < 1.0 ? aspectRatio : 1.0
+            self.heightModifier = aspectRatio > 1.0 ? 1 / aspectRatio : 1.0
         } else {
             self.widthModifier = 1.0
             self.heightModifier = 1.0

--- a/Mochi Diffusion/Views/SidebarControls/ImageWellView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ImageWellView.swift
@@ -9,34 +9,34 @@ import SwiftUI
 
 struct ImageWellView: View {
     var image: CGImage?
+    var aspectRatio: Double
     let setImage: (CGImage?) async -> Void
 
     var body: some View {
         Button {
             Task { await setImage(ImageController.shared.selectImage()) }
         } label: {
-            if let image = image {
-                Image(image, scale: 1, label: Text(verbatim: ""))
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .padding(3)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 2)
-                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                    )
-            } else {
-                Image(systemName: "photo")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .foregroundColor(Color(nsColor: .separatorColor))
-                    .padding(30)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 2)
-                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                    )
+            ZStack {
+                RoundedRectangle(cornerRadius: 2)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
                     .background(.background.opacity(0.01))
+
+                if let image = image {
+                    Image(image, scale: 1, label: Text(verbatim: ""))
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } else {
+                    Image(systemName: "photo")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 30)
+                        .foregroundColor(Color(nsColor: .separatorColor))
+                }
             }
+            .frame(width: 80 * aspectRatio, height: 80)
+            .clipped()
         }
+        .aspectRatio(contentMode: .fill)
         .buttonStyle(.plain)
         .onDrop(of: [.fileURL], isTargeted: nil) { providers in
             _ = providers.first?.loadDataRepresentation(for: .fileURL) { data, _ in

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -20,14 +20,20 @@ struct StartingImageView: View {
         .sidebarLabelFormat()
 
         HStack(alignment: .top) {
-            ImageWellView(image: controller.startingImage) { image in
+            let aspectRatio: Double = {
+                if let size = controller.currentModel?.inputSize {
+                    return size.width / size.height
+                } else {
+                    return 1.0
+                }
+            }()
+            ImageWellView(image: controller.startingImage, aspectRatio: aspectRatio) { image in
                 if let image {
                     ImageController.shared.setStartingImage(image: image)
                 } else {
                     await ImageController.shared.unsetStartingImage()
                 }
             }
-            .frame(height: 90)
 
             Spacer()
 

--- a/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/StartingImageView.swift
@@ -20,20 +20,14 @@ struct StartingImageView: View {
         .sidebarLabelFormat()
 
         HStack(alignment: .top) {
-            let aspectRatio: Double = {
-                if let size = controller.currentModel?.inputSize {
-                    return size.width / size.height
-                } else {
-                    return 1.0
-                }
-            }()
-            ImageWellView(image: controller.startingImage, aspectRatio: aspectRatio) { image in
+            ImageWellView(image: controller.startingImage, size: controller.currentModel?.inputSize) { image in
                 if let image {
                     ImageController.shared.setStartingImage(image: image)
                 } else {
                     await ImageController.shared.unsetStartingImage()
                 }
             }
+            .frame(width: 90, height: 90)
 
             Spacer()
 


### PR DESCRIPTION
fixes https://github.com/godly-devotion/MochiDiffusion/issues/205

## What
- resizes input images in img2img and ControlNet to match the model in generation pipeline
- adjusts aspect ratio of ImageWellView to show how the image will be cropped

## How
- input image dimensions are parsed from VAEEncoder.mlmodelc/metadata.json, stored as `inputSize` in SDModel
  - an early implementation I prototyped instantiated a `CoreML` `ManagedMLModel` object from the VAEEncoder.mlmodelc, to get the size, but it was too slow. Instead we directly open metadata.json and parse the size from that. This is fragile and inflexible, and will need to be updated if the model metadata ever changes, but it is more than 1000% faster
- `CGImage` extension method `scaledAndCroppedTo(size: CGSize)` is used to resize input images in generations
  - cropped to match required aspect ratio
    - so scaling won't squish or stretch image
  - crop is centred, e.g. crops equal amount off both edges
  - scaled to match required size
  - scales up or down
- applies to both img2img and ControlNet input images
- aspect ratio of ImageWellView matches the currently selected model so user can see how input image is being cropped
  - aspect ratio is square if current model doesn't support img2img (or if parsing the size from VAEEncoder.mlmodelc/metadata.json fails for any other reason)
  - image in ImageWellView is positioned in a fixed size frame so that it doesn't change size and move other controls around in the sidebar

## Images
### default square (e.g. 512x512)
<img width="234" alt="Screenshot 2023-11-25 at 9 24 31 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/8458547/7042f0f0-d920-41fc-911e-a205cc5d2be3">
<img width="234" alt="Screenshot 2023-11-25 at 9 24 29 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/8458547/aa206488-0132-4679-9640-22c7c564feeb">

### portrait (e.g. 512x768)
<img width="234" alt="Screenshot 2023-11-25 at 9 24 34 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/8458547/06d1e8a0-c181-49ab-81ce-8c176e3c0289">
<img width="234" alt="Screenshot 2023-11-25 at 9 24 25 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/8458547/dc1d47c3-95ba-40bb-9ff5-1182a1919cf8">

### Landscape (e.g. 768x512)
<img width="234" alt="Screenshot 2023-11-25 at 9 24 37 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/8458547/ede1580f-f6b6-40a8-8d0d-b5f5b0140d8e">
<img width="234" alt="Screenshot 2023-11-25 at 9 24 09 PM" src="https://github.com/godly-devotion/MochiDiffusion/assets/8458547/9881768b-b5ca-44dc-8d1f-b657c2be3e20">

(NB: ImageWellView can conform to any aspect ratio, these are just the common examples)