### PR TITLE
Fix handling of images generated while autosave is disabled

### DIFF
--- a/Mochi Diffusion/Support/Extensions.swift
+++ b/Mochi Diffusion/Support/Extensions.swift
@@ -124,7 +124,7 @@ extension NSImage {
 
     func temporaryFileURL() throws -> URL {
         let imageHash = self.getImageHash()
-        if let cachedURL = Self.urlCache[imageHash] {
+        if let cachedURL = Self.urlCache[imageHash], FileManager.default.fileExists(atPath: cachedURL.path(percentEncoded: false)) {
             return cachedURL
         }
         let name = String(imageHash)

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -145,6 +145,7 @@ final class ImageController: ObservableObject {
                 }
                 ImageStore.shared.images.forEach { sdi in
                     if !fileList.contains(where: {
+                        sdi.path.isEmpty || // ignore images generated with autosave disabled
                         $0 == URL(filePath: sdi.path).lastPathComponent
                     }) {
                         removals.append(sdi)

--- a/Mochi Diffusion/Views/GalleryView.swift
+++ b/Mochi Diffusion/Views/GalleryView.swift
@@ -81,7 +81,20 @@ struct GalleryView: View {
                             .simultaneousGesture(TapGesture().onEnded {
                                 Task { await ImageController.shared.select(sdi.id) }
                             })
-                            .draggable(URL(fileURLWithPath: sdi.path))
+                            .onDrag {
+                                if !sdi.path.isEmpty, let item = NSItemProvider(contentsOf: URL(fileURLWithPath: sdi.path)) {
+                                    return item
+                                }
+
+                                if let cgImage = sdi.image {
+                                    let nsImage = NSImage(cgImage: cgImage, size: CGSize(width: sdi.width, height: sdi.height))
+                                    if let tempURL = try? nsImage.temporaryFileURL(), let item = NSItemProvider(contentsOf: tempURL) {
+                                        return item
+                                    }
+                                }
+
+                                return NSItemProvider()
+                            }
                             .contextMenu {
                                 GalleryItemContextMenuView(sdi: sdi)
                             }


### PR DESCRIPTION
https://github.com/godly-devotion/MochiDiffusion/pull/345 doesn't behave correctly with images generated when "Autosave & Retore Images" is disabled, ie. there are issues with "temp" images which just exist in memory, not the file system

- drag and drop doesn't work with temp images
  - because drag and drop uses the underlying file representation of the file
  - fixed by creating a temp file when trying to drag temp images, and dragging that
- when a change to the images folder is detected, all temp images are removed 
  - because, in the `FolderMonitor` `folderDidChange` closure, if an image in the `GalleryView` doesn't have a corresponding file in the images folder, it assumes the file was removed, and removes the image
  - fixed by adding an exception to the check for temp images
