### PR TITLE
Fix guidance ',' => '.' for proper conversion replacement.

### DIFF
--- a/Mochi Diffusion/Views/SidebarControls/MochiSlider.swift
+++ b/Mochi Diffusion/Views/SidebarControls/MochiSlider.swift
@@ -30,7 +30,7 @@ struct MochiSlider: View {
     private let id = UUID()
 
     func stringToDouble(_ string: String) -> Double? {
-        if let doubleValue = Double(string) {
+        if let doubleValue = Double(string.components(separatedBy: ",").joined(separator: ".")) {
             var newValue = max(doubleValue, bounds.lowerBound)
             if strictUpperBound {
                 newValue = min(newValue, bounds.upperBound)

--- a/Mochi Diffusion/Views/SidebarControls/MochiSlider.swift
+++ b/Mochi Diffusion/Views/SidebarControls/MochiSlider.swift
@@ -30,7 +30,7 @@ struct MochiSlider: View {
     private let id = UUID()
 
     func stringToDouble(_ string: String) -> Double? {
-        if let doubleValue = Double(string.components(separatedBy: ",").joined(separator: ".")) {
+        if let doubleValue = Double(string.replacingOccurrences(of: ",", with: ".")) {
             var newValue = max(doubleValue, bounds.lowerBound)
             if strictUpperBound {
                 newValue = min(newValue, bounds.upperBound)


### PR DESCRIPTION
Guidance slider is not handling mouse clicks, caused by #361 Since Double is not expecting ',' as part of string.