### PR TITLE
feat: add button to view models in Finder

### DIFF
--- a/Mochi Diffusion/Views/SidebarControls/ModelView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ModelView.swift
@@ -22,14 +22,14 @@ struct ModelView: View {
                 }
             }
             .labelsHidden()
-            Button(action: openDirectoryInFinder) {
-                Text("…")
-            }.help("Open models directory in Finder")
-        }
-    }
 
-    private func openDirectoryInFinder() {
-        NSWorkspace.shared.open(URL(fileURLWithPath: controller.modelDir))
+            Button {
+                NSWorkspace.shared.open(URL(fileURLWithPath: controller.modelDir))        
+            } label: {
+                Text(verbatim: "...")
+            }
+            .help("Show models in Finder")
+        }
     }
 }
 

--- a/Mochi Diffusion/Views/SidebarControls/ModelView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ModelView.swift
@@ -24,7 +24,7 @@ struct ModelView: View {
             .labelsHidden()
 
             Button {
-                NSWorkspace.shared.open(URL(fileURLWithPath: controller.modelDir))        
+                NSWorkspace.shared.open(URL(fileURLWithPath: controller.modelDir))
             } label: {
                 Text(verbatim: "...")
             }

--- a/Mochi Diffusion/Views/SidebarControls/ModelView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/ModelView.swift
@@ -5,6 +5,7 @@
 //  Created by Joshua Park on 12/26/22.
 //
 
+import AppKit
 import CoreML
 import SwiftUI
 
@@ -21,7 +22,14 @@ struct ModelView: View {
                 }
             }
             .labelsHidden()
+            Button(action: openDirectoryInFinder) {
+                Text("…")
+            }.help("Open models directory in Finder")
         }
+    }
+
+    private func openDirectoryInFinder() {
+        NSWorkspace.shared.open(URL(fileURLWithPath: controller.modelDir))
     }
 }
 


### PR DESCRIPTION
Tiny UX improvement.

Enable users to quickly access model directory from UI by adding an "Open models directory in Finder" button with appropriate context help, and implement the underlying action with Core's file system operations.

<img width="426" alt="image" src="https://github.com/godly-devotion/MochiDiffusion/assets/334228/6e8d53a8-142d-4bb3-a876-5fbfb2112fb1">
