### PR TITLE
fix: match tokenizer to current selected model

### DIFF
--- a/Mochi Diffusion/Model/SDModel.swift
+++ b/Mochi Diffusion/Model/SDModel.swift
@@ -18,6 +18,7 @@ struct SDModel: Identifiable {
     let controlNet: [String]
     let isXL: Bool
     let inputSize: CGSize?
+    let tokenizer: Tokenizer?
 
     var id: URL { url }
 
@@ -40,10 +41,15 @@ struct SDModel: Identifiable {
         }
         self.isXL = isXL
         self.inputSize = size
+        self.tokenizer = Tokenizer(modelDir: url)
     }
 }
 
 extension SDModel: Hashable {
+    static func == (lhs: SDModel, rhs: SDModel) -> Bool {
+        lhs.url == rhs.url
+    }
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }

--- a/Mochi Diffusion/Support/ImageGenerator.swift
+++ b/Mochi Diffusion/Support/ImageGenerator.swift
@@ -57,8 +57,6 @@ struct GenerationConfig: Sendable, Identifiable {
 
     private var pipeline: (any StableDiffusionPipelineProtocol)?
 
-    private(set) var tokenizer: Tokenizer?
-
     private var generationStopped = false
 
     private(set) var lastStepGenerationElapsedTime: Double?
@@ -205,7 +203,6 @@ struct GenerationConfig: Sendable, Identifiable {
         }
 
         self.currentPipelineHash = hash
-        self.tokenizer = Tokenizer(modelDir: model.url)
         await updateState(.ready(nil))
     }
 

--- a/Mochi Diffusion/Views/SidebarControls/PromptView.swift
+++ b/Mochi Diffusion/Views/SidebarControls/PromptView.swift
@@ -17,7 +17,7 @@ struct PromptTextEditor: View {
 
     @FocusState private var focused: Bool
 
-    @Environment(ImageGenerator.self) private var generator: ImageGenerator
+    let tokenizer: Tokenizer?
 
     private let tokenLimit = 75
 
@@ -32,7 +32,7 @@ struct PromptTextEditor: View {
     }
 
     private var tokens: Int {
-        guard let tokenizer = generator.tokenizer else {
+        guard let tokenizer else {
             return estimatedTokens
         }
         return tokenizer.countTokens(text)
@@ -78,7 +78,6 @@ struct PromptTextEditor: View {
 
 struct PromptView: View {
     @EnvironmentObject private var controller: ImageController
-    @Environment(ImageGenerator.self) private var generator: ImageGenerator
     @Environment(FocusController.self) private var focusCon: FocusController
 
     var body: some View {
@@ -90,7 +89,8 @@ struct PromptView: View {
             PromptTextEditor(
                 text: $controller.prompt,
                 height: 120,
-                focusBinding: $focusCon.promptFieldIsFocused
+                focusBinding: $focusCon.promptFieldIsFocused,
+                tokenizer: controller.currentModel?.tokenizer
             )
 
             Text("Exclude from Image")
@@ -98,7 +98,8 @@ struct PromptView: View {
             PromptTextEditor(
                 text: $controller.negativePrompt,
                 height: 70,
-                focusBinding: $focusCon.negativePromptFieldIsFocused
+                focusBinding: $focusCon.negativePromptFieldIsFocused,
+                tokenizer: controller.currentModel?.tokenizer
             )
 
             Spacer().frame(height: 2)
@@ -145,6 +146,5 @@ struct PromptView: View {
 #Preview {
     PromptView()
         .environmentObject(ImageController.shared)
-        .environment(ImageGenerator.shared)
         .environment(FocusController.shared)
 }


### PR DESCRIPTION
This PR addresses https://github.com/godly-devotion/MochiDiffusion/issues/415

- [x] I have read [CONTRIBUTING.md](https://github.com/godly-devotion/MochiDiffusion/blob/main/CONTRIBUTING.md)

### Description:

 Each model includes a vocab list of tokens which the text can be parsed into. Depending on what words and fragments are in the vocab list, a string can be broken up into a different number of tokens. Token count matters because coreml stable diffusion models have an input limit of 75 tokens.

The tokenizer which calculates the number of tokens in user prompt was created during `ImageGenerator.loadPipeline()`, from the current pipeline model. Since `loadPipeline()` is no longer called whenever a new model is selected (because of queued jobs), it no longer makes sense to update the tokenizer there.

Instead, a tokenizer is created for each model and stored as a property of SDModel at init. When that model is selected, `PromptView` can access the current model and its tokenizer through `ImageController`